### PR TITLE
Add MongoDB backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ python src/run.py --help
 ```
 
 for a description of all available options.
+
+## MongoDB backup script
+
+`scripts/backup_mongodb.sh` dumps a MongoDB database to a Dropbox-synced
+folder. The script starts `mongod` if it is not running and stops it again
+when the backup finishes (if it was started by the script).
+
+Make it executable before scheduling it with `cron`:
+
+```bash
+chmod +x scripts/backup_mongodb.sh
+```
+

--- a/scripts/backup_mongodb.sh
+++ b/scripts/backup_mongodb.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# scripts/backup_mongodb.sh
+# Backup MongoDB database, ensuring mongod is running.
+
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="$HOME/Dropbox/backups"
+DBNAME="DBNAME"
+USERNAME="USERNAME"
+PASSWORD="PASSWORD"
+BACKUP_PATH="$BACKUP_DIR/db_backup_${DATE}"
+
+mkdir -p "$BACKUP_DIR"
+
+# Track whether we started mongod
+started_mongod=false
+
+# Check if mongod process is running
+if pgrep mongod >/dev/null; then
+    echo "mongod is running"
+else
+    echo "mongod is not running. Starting..."
+    if command -v systemctl >/dev/null; then
+        sudo systemctl start mongod
+    else
+        sudo service mongod start
+    fi
+    started_mongod=true
+fi
+
+# Dump the database
+mongodump --db "$DBNAME" --username "$USERNAME" --password "$PASSWORD" --out "$BACKUP_PATH"
+
+# Stop mongod if we started it
+if [ "$started_mongod" = true ]; then
+    echo "Stopping mongod..."
+    if command -v systemctl >/dev/null; then
+        sudo systemctl stop mongod
+    else
+        sudo service mongod stop
+    fi
+fi


### PR DESCRIPTION
## Summary
- add backup_mongodb.sh script to ensure mongod is running before a backup
- document the MongoDB backup script in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685120bcb67c8330aba0239476ba37ed