### PR TITLE
Improve MongoDB backup secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ editing the script.  You may create a file named `~/.mongodb_backup_env` with
 content like:
 
 ```bash
-export DBNAME=mydb
+export DBNAME="fmriprep_stats"
 # export MONGO_USER=myuser
 # export MONGO_PASS=mypassword
 ```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,27 @@ python src/run.py --help
 ```
 
 for a description of all available options.
+
+## MongoDB backup script
+
+`scripts/backup_mongodb.sh` dumps a MongoDB database to a Dropbox-synced
+folder. The script starts `mongod` if it is not running and stops it again
+when the backup finishes (if it was started by the script).
+
+Make it executable before scheduling it with `cron`:
+
+```bash
+chmod +x scripts/backup_mongodb.sh
+```
+
+Store credentials in environment variables rather than editing the script.
+You may create a file named `~/.mongodb_backup_env` with content like:
+
+```bash
+export DBNAME=mydb
+export MONGO_USER=myuser
+export MONGO_PASS=mypassword
+```
+
+The backup script will source this file if present.
+

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ Make it executable before scheduling it with `cron`:
 chmod +x scripts/backup_mongodb.sh
 ```
 
-Store credentials in environment variables rather than editing the script.
-You may create a file named `~/.mongodb_backup_env` with content like:
+Store `DBNAME` (and optional credentials) in environment variables rather than
+editing the script.  You may create a file named `~/.mongodb_backup_env` with
+content like:
 
 ```bash
 export DBNAME=mydb
-export MONGO_USER=myuser
-export MONGO_PASS=mypassword
+# export MONGO_USER=myuser
+# export MONGO_PASS=mypassword
 ```
 
 The backup script will source this file if present.

--- a/scripts/backup_mongodb.sh
+++ b/scripts/backup_mongodb.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# scripts/backup_mongodb.sh
+# Backup MongoDB database, ensuring mongod is running.
+
+set -euo pipefail
+
+# Optionally source credentials from ~/.mongodb_backup_env
+ENV_FILE="$HOME/.mongodb_backup_env"
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+fi
+
+# Require credentials via environment variables
+: "${DBNAME:?Set DBNAME, e.g., export DBNAME=your_db}"
+: "${MONGO_USER:?Set MONGO_USER, e.g., export MONGO_USER=username}"
+: "${MONGO_PASS:?Set MONGO_PASS, e.g., export MONGO_PASS=password}"
+
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="$HOME/Dropbox/backups"
+BACKUP_PATH="$BACKUP_DIR/db_backup_${DATE}"
+
+mkdir -p "$BACKUP_DIR"
+
+# Track whether we started mongod
+started_mongod=false
+
+# Check if mongod process is running
+if pgrep mongod >/dev/null; then
+    echo "mongod is running"
+else
+    echo "mongod is not running. Starting..."
+    if command -v systemctl >/dev/null; then
+        sudo systemctl start mongod
+    else
+        sudo service mongod start
+    fi
+    started_mongod=true
+fi
+
+# Dump the database
+mongodump --db "$DBNAME" \
+    --username "$MONGO_USER" --password "$MONGO_PASS" \
+    --out "$BACKUP_PATH"
+
+# Stop mongod if we started it
+if [ "$started_mongod" = true ]; then
+    echo "Stopping mongod..."
+    if command -v systemctl >/dev/null; then
+        sudo systemctl stop mongod
+    else
+        sudo service mongod stop
+    fi
+fi

--- a/scripts/backup_mongodb.sh
+++ b/scripts/backup_mongodb.sh
@@ -11,10 +11,8 @@ if [ -f "$ENV_FILE" ]; then
     source "$ENV_FILE"
 fi
 
-# Require credentials via environment variables
+# DBNAME is required; credentials are optional
 : "${DBNAME:?Set DBNAME, e.g., export DBNAME=your_db}"
-: "${MONGO_USER:?Set MONGO_USER, e.g., export MONGO_USER=username}"
-: "${MONGO_PASS:?Set MONGO_PASS, e.g., export MONGO_PASS=password}"
 
 DATE=$(date +%Y-%m-%d)
 BACKUP_DIR="$HOME/Dropbox/backups"
@@ -38,10 +36,17 @@ else
     started_mongod=true
 fi
 
+# Build mongodump options
+dump_opts=(--db "$DBNAME" --out "$BACKUP_PATH")
+if [ -n "${MONGO_USER:-}" ]; then
+    dump_opts+=(--username "$MONGO_USER")
+fi
+if [ -n "${MONGO_PASS:-}" ]; then
+    dump_opts+=(--password "$MONGO_PASS")
+fi
+
 # Dump the database
-mongodump --db "$DBNAME" \
-    --username "$MONGO_USER" --password "$MONGO_PASS" \
-    --out "$BACKUP_PATH"
+mongodump "${dump_opts[@]}"
 
 # Stop mongod if we started it
 if [ "$started_mongod" = true ]; then


### PR DESCRIPTION
## Summary
- secure MongoDB backup script by sourcing credentials from environment variables
- document how to store DB credentials in `~/.mongodb_backup_env`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685120bcb67c8330aba0239476ba37ed