### PR TITLE
Clone nipreps.github.io in temp dir when updating plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ The backup script will source this file if present.
 ## Weekly plot update script
 
 `scripts/update_plots.sh` generates plots with `src/run.py plot` and pushes them
-to a clone of the `nipreps.github.io` website. The path to that clone can be
-given as an argument and defaults to `$HOME/workspace/nipreps.github.io`.
-The script may be run from any directory and validates that the target is a Git
-repository.
+to the `nipreps.github.io` website. The script clones the repository to a
+temporary directory (by default using `git@github.com:nipreps/nipreps.github.io.git`),
+writes the plots there, commits and pushes the changes, and removes the
+temporary clone.  You may pass an alternative repository URL as an argument.
+The script may be run from any directory.
 
 Make the script executable:
 

--- a/scripts/update_plots.sh
+++ b/scripts/update_plots.sh
@@ -4,14 +4,17 @@
 
 set -euo pipefail
 
-REPO_DIR="${1:-$HOME/workspace/nipreps.github.io}"
-ASSETS_DIR="$REPO_DIR/docs/assets"
+REPO_URL="${1:-git@github.com:nipreps/nipreps.github.io.git}"
+TMP_REPO="$(mktemp -d)"
 
-if [ ! -d "$REPO_DIR/.git" ]; then
-    echo "Error: $REPO_DIR is not a git repository" >&2
-    exit 1
-fi
+cleanup() {
+    rm -rf "$TMP_REPO"
+}
+trap cleanup EXIT
 
+git clone "$REPO_URL" "$TMP_REPO"
+
+ASSETS_DIR="$TMP_REPO/docs/assets"
 mkdir -p "$ASSETS_DIR"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,7 +22,7 @@ cd "$SCRIPT_DIR/.."
 
 python src/run.py plot -o "$ASSETS_DIR"
 
-cd "$REPO_DIR"
+cd "$TMP_REPO"
 git pull --ff-only
 git add docs/assets
 if ! git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- rework `scripts/update_plots.sh` to clone the website repo into a temporary
  directory, generate the plots, commit and push, then clean up
- document new behaviour in the README

## Testing
- `bash -n scripts/update_plots.sh`
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68557dac3ea88330a24eeb28a2e5ce97