### PR TITLE
ENH: Decouple Sentry fetch and MongoDB storage + CI workflow

### DIFF
--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -26,7 +26,7 @@ jobs:
           END_TIME=$(date -u -d "today 00:00:00" +%Y-%m-%dT%H:%M:%S)
           python src/run.py get \
             --event started \
-            --start-time "${START_TIME}" \
-            --end-time "${END_TIME}" \
+            --start-date "${START_TIME}" \
+            --end-date "${END_TIME}" \
             --no-store \
             --print-dataframe

--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -1,0 +1,32 @@
+name: Sentry fetch preview
+
+on:
+  pull_request:
+
+jobs:
+  fetch-preview:
+    runs-on: ubuntu-latest
+    env:
+      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch previous day and print dataframe preview
+        run: |
+          START_TIME=$(date -u -d "yesterday 00:00:00" +%Y-%m-%dT%H:%M:%S)
+          END_TIME=$(date -u -d "today 00:00:00" +%Y-%m-%dT%H:%M:%S)
+          python src/run.py get \
+            --event started \
+            --start-time "${START_TIME}" \
+            --end-time "${END_TIME}" \
+            --no-store \
+            --print-dataframe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 pymongo
 pandas
+numpy
+packaging
 matplotlib
+scipy
 seaborn
 notebook
 nbconvert
 requests
+click

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ notebook
 nbconvert
 requests
 click
+tqdm


### PR DESCRIPTION
### Motivation
- Allow precise time-window fetching and optional non-persistent runs so CI can preview fetched data without requiring MongoDB.
- Add an automated preview on pull requests that fetches the previous day and prints a pandas dataframe using the `SENTRY_TOKEN` secret.

### Description
- Update `src/run.py` to add `--start-time`/`--end-time` flags, a `_ensure_timezone` helper, `--store/--no-store` and `--print-dataframe` toggles, conditional `id_lookup` wiring, and dataframe preview printing.
- Change `src/api.py` to introduce `normalize_events`, accept an optional `id_lookup`, and return `pandas.DataFrame` results from `fetch_window` and `parallel_fetch` instead of writing directly to MongoDB.
- Add `mongo_id_lookup` and `store_events` helpers to `src/db.py` to provide a cached-id lookup callable and a DataFrame/records persistence function.
- Add `.github/workflows/sentry-fetch-pr.yml` to run on `pull_request`, install dependencies, and invoke the CLI to fetch the previous day with `--no-store --print-dataframe` while using the `SENTRY_TOKEN` secret.

### Testing
- No automated tests were executed as part of this change; a GitHub Actions job has been added to run on pull requests and will exercise the CLI when a `SENTRY_TOKEN` secret is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735deaf2b48330bbe42bb9aeafc1af)