### PR TITLE
FEAT: add parquet storage option and keep dataframe preview as preview-only

### DIFF
--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -20,13 +20,12 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Fetch previous day and print dataframe preview
+      - name: Fetch previous day and write parquet output
         run: |
           START_TIME=$(date -u -d "yesterday 00:00:00" +%Y-%m-%dT%H:%M:%S)
           END_TIME=$(date -u -d "today 00:00:00" +%Y-%m-%dT%H:%M:%S)
           python src/run.py get \
-            --event started \
+            --event failed \
             --start-date "${START_TIME}" \
             --end-date "${END_TIME}" \
-            --no-store \
-            --print-dataframe
+            --store parquet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pymongo
 pandas
+pyarrow
 numpy
 packaging
 matplotlib


### PR DESCRIPTION
### Motivation
- Make storage behavior explicit by allowing selection between MongoDB and parquet file outputs via `--store` instead of a boolean flag. 
- Preserve the existing `--print-dataframe` behavior as a read-only preview that does not trigger storage side effects. 
- Ensure parquet outputs are safe and predictable by sanitizing event names and creating the output directory when needed. 

### Description
- Replaced the boolean `--store/--no-store` option with `--store` as a `click.Choice` of `"mongo"` or `"parquet"`, defaulting to `mongo`. 
- Added `-o/--output-folder` option for parquet output and updated its help text to reference `--store parquet`. 
- Introduced `_sanitize_event_name` helper to produce filesystem-safe filenames and used `Path(...).mkdir(parents=True, exist_ok=True)` before writing parquet files. 
- Modified runtime flow so `--print-dataframe` prints a preview and `continue`s (no storage), `store == "mongo"` uses `store_events(...)`, and `store == "parquet"` writes per-event files named `<last_complete_day>-<sanitized_event>.parquet`. 

### Testing
- No automated tests were run because the repository does not contain an automated test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737bb2a7cc83309ddd8e352bfac1a2)