### PR TITLE
FEAT: upload parquet artifacts

### DIFF
--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -29,3 +29,9 @@ jobs:
             --start-date "${START_TIME}" \
             --end-date "${END_TIME}" \
             --store parquet
+
+      - name: Upload parquet artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fmriprep-stats-parquet
+          path: "*.parquet"


### PR DESCRIPTION
### Motivation
- Capture parquet outputs produced by the fetch/CLI job so they are available as workflow artifacts for inspection.

### Description
- Add an `Upload parquet artifacts` step to `.github/workflows/sentry-fetch-pr.yml` that uses `actions/upload-artifact@v4`, names the artifact `fmriprep-stats-parquet`, and uploads files matching `*.parquet`, placed immediately after the parquet generation step.

### Testing
- No automated tests exist in the repository, so no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697381e5fa488330979c5a9ddb37cea8)