### PR TITLE
FEAT: restore version stream annotations

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -377,9 +377,9 @@ def plot_version_stream(
         axes[ax_i].set_xlabel(f"{yr}", fontsize=18)
         year_start_index = year_end_index
 
-    totals = data.sum(axis=1).to_numpy()
-    baseline_shift = -0.5 * totals
-    y_top = 0.5 * totals.max()
+    smoothed_totals = smoothed_data.sum(axis=1)
+    baseline_shift = -0.5 * smoothed_totals
+    y_top = 0.5 * smoothed_totals.max()
     starts = {}
     for idx, label in enumerate(labels):
         series = data[label].to_numpy()
@@ -396,11 +396,14 @@ def plot_version_stream(
         return axes[-1]
 
     def _center_y(label, xpos):
-        xpos = min(max(int(xpos), 0), len(data) - 1)
-        values = data.iloc[xpos].to_numpy()
+        x_idx = np.searchsorted(xnew, xpos)
+        x_idx = min(max(x_idx, 0), len(xnew) - 1)
+        if x_idx > 0 and abs(xnew[x_idx] - xpos) > abs(xnew[x_idx - 1] - xpos):
+            x_idx -= 1
+        values = smoothed_data[x_idx]
         cum = np.cumsum(values)
-        idx = list(labels).index(label)
-        center = baseline_shift[xpos] + cum[idx] - values[idx] / 2.0
+        label_idx = list(labels).index(label)
+        center = baseline_shift[x_idx] + cum[label_idx] - values[label_idx] / 2.0
         return center
 
     left_positions = []


### PR DESCRIPTION
### Motivation
- Restore the rich, notebook-derived annotations on the version stream to improve readability of the stacked stream visualization and make version labels visible on the colored streams.
- Ensure labels remain legible against the stream colors by computing contrast-aware text color and avoid overlapping labels via simple placement heuristics.

### Description
- Updated `src/viz.py` and `plot_version_stream` to reintroduce annotation support and added an import for `matplotlib.colors` as `mpl_colors`.
- Added helper functions `
_label_color` to pick high-contrast text color and `
_label_text` to normalize specific labels (e.g., `20.2 -> 20.2 (LTS)`).
- Implemented placement logic that computes `totals`, `baseline_shift`, per-version `starts`, separates `left_labels` and `later_labels`, applies a `min_gap`-based stacking for left-side labels, and staggered placement for later labels with per-axis resolution via `_axis_for_x` and `_center_y`.
- Annotations are drawn with colored rounded `bbox` backgrounds and wedge `arrowprops` so label backgrounds match the stream colors while keeping text legible.

### Testing
- No automated tests were run because there are no automated tests in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697393366e4883308dfa9f77cca40d27)