### PR TITLE
FEAT: add daily parquet export script

### DIFF
--- a/scripts/export_daily_parquet.py
+++ b/scripts/export_daily_parquet.py
@@ -1,54 +1,276 @@
-#!/usr/bin/env python3
-"""Stub exporter for CI workflows.
+#!/usr/bin/env python
+"""Export MongoDB events into daily parquet files.
 
-Validates MongoDB connectivity and accepts the CLI arguments used in CI.
+The latest complete day is determined by looking up the maximum ``dateCreated``
+value across the requested events, truncating it to a date, and checking whether
+that timestamp falls within the current day (in the selected timezone, default
+UTC). If the max timestamp is within the current day, the latest complete day
+is assumed to be the previous day.
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
+import os
+import re
+import sys
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
+from typing import Iterable
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from pymongo import MongoClient
+from zoneinfo import ZoneInfo
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.api import ISSUES
+
+DEFAULT_BATCH_SIZE = 1000
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Stub daily parquet exporter for CI validation."
+def _sanitize_event_name(event_name: str) -> str:
+    normalized = event_name.strip().lower()
+    normalized = normalized.replace(os.sep, "_")
+    if os.altsep:
+        normalized = normalized.replace(os.altsep, "_")
+    normalized = re.sub(r"[^a-z0-9_.-]+", "_", normalized)
+    normalized = normalized.strip("_")
+    return normalized or "event"
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        parsed = datetime.fromisoformat(value)
+        return parsed.date()
+
+
+def _normalize_timestamp(value: datetime, tz: ZoneInfo) -> datetime:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(tz)
+
+
+def _get_collection_edge(collection, sort_direction: int) -> datetime | None:
+    doc = collection.find_one(sort=[("dateCreated", sort_direction)])
+    if not doc:
+        return None
+    return doc.get("dateCreated")
+
+
+def _get_date_bounds(db, events: Iterable[str], tz: ZoneInfo) -> tuple[date, datetime]:
+    min_candidates = []
+    max_candidates = []
+    for event in events:
+        collection = db[event]
+        min_ts = _get_collection_edge(collection, 1)
+        max_ts = _get_collection_edge(collection, -1)
+        if min_ts is not None:
+            min_candidates.append(_normalize_timestamp(min_ts, tz))
+        if max_ts is not None:
+            max_candidates.append(_normalize_timestamp(max_ts, tz))
+    if not min_candidates or not max_candidates:
+        raise RuntimeError("No records found in MongoDB for requested events.")
+    earliest = min(min_candidates).date()
+    latest = max(max_candidates)
+    return earliest, latest
+
+
+def _latest_complete_day(max_timestamp: datetime, tz: ZoneInfo) -> date:
+    max_ts = _normalize_timestamp(max_timestamp, tz)
+    today = datetime.now(tz).date()
+    latest_day = max_ts.date()
+    if latest_day == today:
+        return latest_day - timedelta(days=1)
+    return latest_day
+
+
+def _resolve_day_range(
+    *,
+    earliest: date,
+    latest_complete: date,
+    start_date: date | None,
+    end_date: date | None,
+    num_days: int | None,
+) -> list[date]:
+    if start_date and end_date:
+        if start_date > end_date:
+            raise ValueError("start-date cannot be after end-date")
+        start = start_date
+        end = end_date
+    elif end_date:
+        end = end_date
+        if num_days:
+            start = end - timedelta(days=num_days - 1)
+        else:
+            start = earliest
+    elif start_date:
+        start = start_date
+        if num_days:
+            end = start + timedelta(days=num_days - 1)
+        else:
+            end = latest_complete
+    else:
+        end = latest_complete
+        if num_days:
+            start = end - timedelta(days=num_days - 1)
+        else:
+            start = earliest
+    if start > end:
+        return []
+    days = []
+    current = start
+    while current <= end:
+        days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def _iter_batches(cursor, batch_size: int):
+    batch = []
+    for doc in cursor:
+        batch.append(doc)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _prepare_dataframe(records: list[dict]) -> pd.DataFrame:
+    for record in records:
+        if "_id" in record:
+            record["_id"] = str(record["_id"])
+    frame = pd.DataFrame(records)
+    if "dateCreated" in frame.columns:
+        frame["dateCreated"] = pd.to_datetime(frame["dateCreated"])
+    return frame
+
+
+def _write_parquet(collection, day: date, output_path: Path, tz: ZoneInfo) -> int:
+    day_start = datetime.combine(day, time.min, tzinfo=tz).astimezone(timezone.utc)
+    day_end = datetime.combine(day + timedelta(days=1), time.min, tzinfo=tz).astimezone(
+        timezone.utc
+    )
+    query = {
+        "dateCreated": {
+            "$gte": day_start.replace(tzinfo=None),
+            "$lt": day_end.replace(tzinfo=None),
+        }
+    }
+    cursor = collection.find(query, batch_size=DEFAULT_BATCH_SIZE)
+    writer = None
+    total = 0
+    for batch in _iter_batches(cursor, DEFAULT_BATCH_SIZE):
+        frame = _prepare_dataframe(batch)
+        table = pa.Table.from_pandas(frame, preserve_index=False)
+        if writer is None:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            writer = pq.ParquetWriter(output_path, table.schema)
+        writer.write_table(table)
+        total += len(frame)
+    if writer:
+        writer.close()
+    return total
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export daily parquet files from MongoDB")
+    parser.add_argument(
+        "--events",
+        nargs="+",
+        default=list(ISSUES.keys()),
+        help="Events to export (default: all ISSUES keys)",
     )
     parser.add_argument(
         "--output-dir",
         required=True,
-        help="Destination directory for parquet output.",
+        help="Directory to write parquet files",
     )
+    parser.add_argument("--num-days", type=int, default=None, help="Number of days to export")
+    parser.add_argument("--start-date", type=_parse_date, default=None)
+    parser.add_argument("--end-date", type=_parse_date, default=None)
     parser.add_argument(
-        "--events",
-        nargs="+",
-        required=True,
-        help="Event names to export.",
+        "--timezone",
+        default="UTC",
+        help="Timezone name for day boundaries (default: UTC)",
     )
-    parser.add_argument(
-        "--num-days",
-        type=int,
-        required=True,
-        help="Number of days to export.",
-    )
-    parser.add_argument(
-        "--mongo-uri",
-        default="mongodb://localhost:27017",
-        help="MongoDB connection URI.",
-    )
-    return parser.parse_args()
+    return parser
 
 
-def main() -> None:
-    args = parse_args()
-    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
 
-    client = MongoClient(args.mongo_uri, serverSelectionTimeoutMS=5000)
-    client.admin.command("ping")
-    client.list_database_names()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    try:
+        tz = ZoneInfo(args.timezone)
+    except Exception as exc:  # pragma: no cover - CLI guard
+        logging.error("Invalid timezone '%s': %s", args.timezone, exc)
+        return 2
+
+    try:
+        client = MongoClient()
+        client.admin.command("ping")
+    except Exception as exc:
+        logging.error("Failed to connect to MongoDB: %s", exc)
+        return 1
+
+    db = client.fmriprep_stats
+    events = args.events
+
+    try:
+        earliest, latest_ts = _get_date_bounds(db, events, tz)
+    except Exception as exc:
+        logging.error("Failed to determine date bounds: %s", exc)
+        return 1
+
+    latest_complete = _latest_complete_day(latest_ts, tz)
+    days = _resolve_day_range(
+        earliest=earliest,
+        latest_complete=latest_complete,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        num_days=args.num_days,
+    )
+
+    if not days:
+        logging.warning("No days resolved for export.")
+        return 0
+
+    output_dir = Path(args.output_dir)
+    summary = {event: {"files": 0, "records": 0} for event in events}
+
+    for event in events:
+        collection = db[event]
+        safe_event = _sanitize_event_name(event)
+        for day in days:
+            output_path = output_dir / f"{day:%Y%m%d}-{safe_event}.parquet"
+            logging.info("Exporting %s for %s to %s", event, day.isoformat(), output_path)
+            count = _write_parquet(collection, day, output_path, tz)
+            if count:
+                summary[event]["files"] += 1
+                summary[event]["records"] += count
+                logging.info("Wrote %s records for %s (%s)", count, event, day)
+            else:
+                logging.info("No records for %s on %s", event, day)
+    client.close()
+
+    logging.info("Export summary:")
+    for event, stats in summary.items():
+        logging.info("%s: %s files, %s records", event, stats["files"], stats["records"])
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())
+


### PR DESCRIPTION
(supersedes #26)

### Motivation
- Provide a reusable CLI to export MongoDB event records as per-day parquet files for downstream analysis and archival.
- Make date boundaries explicit and timezone-aware so exports are consistent across environments and avoid partial-day data.
- Avoid loading entire collections into memory by using cursor batching and per-day queries.

### Description
- Add `scripts/export_daily_parquet.py` which connects to MongoDB via `pymongo.MongoClient()` and writes files named `YYYYMMDD-<event>.parquet` to a configurable `--output-dir`.
- Implement CLI args `--events`, `--output-dir`, `--num-days`, `--start-date`, `--end-date`, and `--timezone` and resolve date ranges per the specified rules (inclusive/exclusive rules applied accordingly).
- Determine the "latest complete day" by inspecting the max `dateCreated` across requested events, truncating to date, and subtracting one day when the max timestamp falls within the current day in the selected timezone, as a completeness heuristic.
- Query each per-day window with `dateCreated` in `[day_start, day_end)` using cursor iteration and batching (`batch_size`) to write parquet only when results exist, sanitize event names via a local `_sanitize_event_name` helper, and log per-event/day progress and a final summary; the script exits non-zero on MongoDB connection failures.

### Testing
- No automated tests exist for this repository and none were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4f68b508330a57eee5e7751f528) (#26)
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4f68b508330a57eee5e7751f528) (this one)