### PR TITLE
FIX: restore mongo dump from dump directory

### DIFF
--- a/.github/workflows/export-daily-parquet.yml
+++ b/.github/workflows/export-daily-parquet.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Restore dump
         env:
           MONGO_CONTAINER: ${{ job.services.mongo.id }}
-        run: docker exec "${MONGO_CONTAINER}" mongorestore --drop /tmp/fmriprep_stats
+        run: docker exec "${MONGO_CONTAINER}" mongorestore --drop /tmp/fmriprep_stats/dump
 
       - name: Export one day
         run: |


### PR DESCRIPTION
### Motivation
- Fix the GitHub Actions workflow where `mongorestore` pointed at `/tmp/fmriprep_stats` and could be a no-op for archives that unpack into a `dump/` subdirectory by targeting the actual dump root.

### Description
- Update `.github/workflows/export-daily-parquet.yml` to run `mongorestore --drop /tmp/fmriprep_stats/dump` instead of `mongorestore --drop /tmp/fmriprep_stats` so the restore uses the correct archive layout.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974cba8c34083309051da59207b6fb3)