### PR TITLE
FEAT: Add mongo-to-parquet export script

### DIFF
--- a/scripts/export_daily_parquet.py
+++ b/scripts/export_daily_parquet.py
@@ -52,10 +52,20 @@ def _parse_date(value: str) -> date:
         return parsed.date()
 
 
-def _normalize_timestamp(value: datetime, tz: ZoneInfo) -> datetime:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(tz)
+def _coerce_datetime(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    raise TypeError(f"Unsupported timestamp type: {type(value)!r}")
+
+
+def _normalize_timestamp(value: datetime | str, tz: ZoneInfo) -> datetime:
+    parsed = _coerce_datetime(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(tz)
 
 
 def _get_collection_edge(collection, sort_direction: int) -> datetime | None:
@@ -273,4 +283,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
(supersedes #26, #28)

### Motivation
- Provide a reusable CLI to export MongoDB event records as per-day parquet files for downstream analysis and archival.
- Make date boundaries explicit and timezone-aware so exports are consistent across environments and avoid partial-day data.
- Avoid loading entire collections into memory by using cursor batching and per-day queries.

### Description
- Add `scripts/export_daily_parquet.py` which connects to MongoDB via `pymongo.MongoClient()` and writes files named `YYYYMMDD-<event>.parquet` to a configurable `--output-dir`.
- Implement CLI args `--events`, `--output-dir`, `--num-days`, `--start-date`, `--end-date`, and `--timezone` and resolve date ranges per the specified rules (inclusive/exclusive rules applied accordingly).
- Determine the "latest complete day" by inspecting the max `dateCreated` across requested events, truncating to date, and subtracting one day when the max timestamp falls within the current day in the selected timezone, as a completeness heuristic.
- Query each per-day window with `dateCreated` in `[day_start, day_end)` using cursor iteration and batching (`batch_size`) to write parquet only when results exist, sanitize event names via a local `_sanitize_event_name` helper, and log per-event/day progress and a final summary; the script exits non-zero on MongoDB connection failures.

### Testing
- No automated tests exist for this repository and none were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f4f68b508330a57eee5e7751f528) (#26, #28)
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d0b299688330aa6e5b096d9329e3)