### PR TITLE
FEAT: Upload parquet export artifact

### DIFF
--- a/.github/workflows/export-daily-parquet.yml
+++ b/.github/workflows/export-daily-parquet.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   export-daily-parquet:
     runs-on: ubuntu-latest
+    env:
+      PARQUET_OUTPUT_DIR: /tmp/parquet
     services:
       mongo:
         image: mongo:6.0
@@ -65,16 +67,23 @@ jobs:
       - name: Export one day
         run: |
           python scripts/export_daily_parquet.py \
-            --output-dir /tmp/parquet \
+            --output-dir "${PARQUET_OUTPUT_DIR}" \
             --events success \
             --num-days 1
 
       - name: Export one week
         run: |
           python scripts/export_daily_parquet.py \
-            --output-dir /tmp/parquet \
+            --output-dir "${PARQUET_OUTPUT_DIR}" \
             --events success \
             --num-days 7
 
       - name: List parquet outputs
-        run: ls -la /tmp/parquet
+        run: ls -la "${PARQUET_OUTPUT_DIR}"
+
+      - name: Upload parquet artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-parquet-export
+          path: ${{ env.PARQUET_OUTPUT_DIR }}
+          retention-days: 3


### PR DESCRIPTION
### Motivation
- Archive the parquet exports from the CI run and prevent mismatched output paths by centralizing the export directory.

### Description
- Add a job-level `PARQUET_OUTPUT_DIR` env, use it for the `--output-dir` and `ls` steps, and add an `actions/upload-artifact@v4` step named `daily-parquet-export` with `retention-days: 3` to upload the parquet directory.

### Testing
- No automated tests were run because this change modifies only the GitHub Actions workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d3f1d6e88330a3cf71cf0ad96c4a)