### PR TITLE
FEAT: Add parquet data source for plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ python src/run.py plot
 will generate the performance and version stream plots using the records stored
 in MongoDB.
 
+To generate plots from parquet snapshots stored in a single directory (files
+named `YYYY-MM-DD-<event>.parquet`), pass the source and parquet directory:
+
+```bash
+python src/run.py plot --source parquet --parquet-dir /path/to/parquet/files
+```
+
+To render plots from both sources in one run, use `--source both`. Output files
+will include `_mongo` and `_parquet` suffixes to avoid overwriting:
+
+```bash
+python src/run.py plot --source both --parquet-dir /path/to/parquet/files
+```
+
+To compare weekly aggregate counts between MongoDB and parquet, add the
+`--compare-sources` flag (this requires parquet access as well):
+
+```bash
+python src/run.py plot --source parquet --parquet-dir /path/to/parquet/files --compare-sources
+```
+
 ## MongoDB backup script
 
 `scripts/backup_mongodb.sh` dumps a MongoDB database and creates a compressed

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -1,0 +1,61 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+"""Data access utilities for plotting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import pyarrow.dataset as ds
+
+from db import load_event as load_event_mongo
+from db import normalize_event_frame
+
+DEFAULT_COLUMNS = ("id", "run_uuid", "dateCreated", "environment_version")
+
+
+def _resolve_parquet_files(parquet_dir: str | Path, event_name: str) -> list[Path]:
+    parquet_dir = Path(parquet_dir)
+    if not parquet_dir.exists():
+        raise FileNotFoundError(f"Parquet directory not found: {parquet_dir}")
+    files = sorted(parquet_dir.glob(f"*-{event_name}.parquet"))
+    if not files:
+        raise FileNotFoundError(
+            f"No parquet files found for event '{event_name}' in {parquet_dir}"
+        )
+    return files
+
+
+def load_event_parquet(
+    event_name: str,
+    parquet_dir: str | Path,
+    unique: bool = True,
+    columns: Iterable[str] = DEFAULT_COLUMNS,
+) -> pd.DataFrame:
+    """Load an event from parquet files in a directory."""
+    files = _resolve_parquet_files(parquet_dir, event_name)
+    dataset = ds.dataset([str(path) for path in files], format="parquet")
+    table = dataset.to_table(columns=list(columns))
+    data = table.to_pandas()
+    return normalize_event_frame(data, unique=unique)
+
+
+def load_event(
+    event_name: str,
+    source: str = "mongo",
+    parquet_dir: str | Path | None = None,
+    unique: bool = True,
+    columns: Iterable[str] = DEFAULT_COLUMNS,
+) -> pd.DataFrame:
+    """Load event data from the requested source."""
+    source = source.lower()
+    if source == "mongo":
+        return load_event_mongo(event_name, unique=unique)
+    if source == "parquet":
+        if parquet_dir is None:
+            raise ValueError("parquet_dir is required when source='parquet'")
+        return load_event_parquet(
+            event_name, parquet_dir=parquet_dir, unique=unique, columns=columns
+        )
+    raise ValueError(f"Unknown source '{source}'")

--- a/src/run.py
+++ b/src/run.py
@@ -279,6 +279,12 @@ def plot(output_dir, drop_cutoff, source, parquet_dir, compare_sources):
     if "parquet" in sources and not parquet_dir:
         click.echo("ERROR: --parquet-dir is required for parquet sources.", err=True)
         sys.exit(2)
+    if compare_sources and not parquet_dir:
+        click.echo(
+            "ERROR: --parquet-dir is required when using --compare-sources.",
+            err=True,
+        )
+        sys.exit(2)
 
     for source_name in sources:
         suffix = "" if source_name == "mongo" and source != "both" else f"_{source_name}"

--- a/src/run.py
+++ b/src/run.py
@@ -30,7 +30,8 @@ from datetime import datetime, timezone, timedelta
 
 import click
 from api import parallel_fetch, ISSUES, DEFAULT_MAX_ERRORS
-from db import load_event, massage_versions, mongo_id_lookup, store_events
+from data_sources import load_event as load_event_source
+from db import massage_versions, mongo_id_lookup, store_events
 from viz import plot_performance, plot_version_stream
 
 DEFAULT_DAYS_WINDOW = 90
@@ -215,24 +216,103 @@ def get(
     click.echo(f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S} [Finished]")
 
 
+def _weekly_counts(dataframe):
+    return dataframe.groupby(
+        [
+            dataframe["date_minus_time"].dt.isocalendar().year,
+            dataframe["date_minus_time"].dt.isocalendar().week,
+        ]
+    )["id"].count()
+
+
+def _compare_sources(started_mongo, success_mongo, started_parquet, success_parquet):
+    mongo_started = _weekly_counts(started_mongo)
+    mongo_success = _weekly_counts(success_mongo)
+    parquet_started = _weekly_counts(started_parquet)
+    parquet_success = _weekly_counts(success_parquet)
+
+    aligned_started = mongo_started.align(parquet_started, fill_value=0)
+    aligned_success = mongo_success.align(parquet_success, fill_value=0)
+
+    started_diff = (aligned_started[0] - aligned_started[1]).abs()
+    success_diff = (aligned_success[0] - aligned_success[1]).abs()
+
+    click.echo("Comparison summary (weekly counts):")
+    click.echo(f"- Max started diff: {started_diff.max()}")
+    click.echo(f"- Max success diff: {success_diff.max()}")
+    click.echo(f"- Total started diff: {started_diff.sum()}")
+    click.echo(f"- Total success diff: {success_diff.sum()}")
+
+
 @cli.command()
-@click.option("-o", "--output-dir", type=click.Path(file_okay=False, dir_okay=True, writable=True), default=".")
+@click.option(
+    "-o",
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True),
+    default=".",
+)
 @click.option("--drop-cutoff", default=None, help="Ignore versions older than this")
-def plot(output_dir, drop_cutoff):
-    """Generate plots using records stored in MongoDB."""
+@click.option(
+    "--source",
+    type=click.Choice(["mongo", "parquet", "both"], case_sensitive=False),
+    default="mongo",
+    show_default=True,
+    help="Data source to use for plots.",
+)
+@click.option(
+    "--parquet-dir",
+    type=click.Path(file_okay=False, dir_okay=True, readable=True),
+    default=None,
+    help="Directory containing parquet files (required for parquet source).",
+)
+@click.option(
+    "--compare-sources/--no-compare-sources",
+    default=False,
+    help="Compare aggregate counts between MongoDB and parquet sources.",
+)
+def plot(output_dir, drop_cutoff, source, parquet_dir, compare_sources):
+    """Generate plots using records stored in MongoDB or parquet files."""
     today = datetime.now().date().strftime("%Y%m%d")
-    out_perf = os.path.join(output_dir, f"{today}_weekly.png")
-    out_ver = os.path.join(output_dir, f"{today}_versionstream.png")
 
-    unique_started = load_event("started")
-    unique_success = load_event("success")
+    source = source.lower()
+    sources = ["mongo", "parquet"] if source == "both" else [source]
+    if "parquet" in sources and not parquet_dir:
+        click.echo("ERROR: --parquet-dir is required for parquet sources.", err=True)
+        sys.exit(2)
 
-    plot_performance(unique_started, unique_success, drop_cutoff=drop_cutoff, out_file=out_perf)
-    click.echo(f"Saved {out_perf}.")
+    for source_name in sources:
+        suffix = "" if source_name == "mongo" and source != "both" else f"_{source_name}"
+        out_perf = os.path.join(output_dir, f"{today}_weekly{suffix}.png")
+        out_ver = os.path.join(output_dir, f"{today}_versionstream{suffix}.png")
 
-    started_v, success_v = massage_versions(unique_started, unique_success)
-    plot_version_stream(started_v, success_v, drop_cutoff=drop_cutoff, out_file=out_ver)
-    click.echo(f"Saved {out_ver}")
+        unique_started = load_event_source(
+            "started", source=source_name, parquet_dir=parquet_dir
+        )
+        unique_success = load_event_source(
+            "success", source=source_name, parquet_dir=parquet_dir
+        )
+
+        plot_performance(
+            unique_started, unique_success, drop_cutoff=drop_cutoff, out_file=out_perf
+        )
+        click.echo(f"Saved {out_perf}.")
+
+        started_v, success_v = massage_versions(unique_started, unique_success)
+        plot_version_stream(
+            started_v, success_v, drop_cutoff=drop_cutoff, out_file=out_ver
+        )
+        click.echo(f"Saved {out_ver}")
+
+    if compare_sources:
+        started_mongo = load_event_source("started", source="mongo")
+        success_mongo = load_event_source("success", source="mongo")
+        started_parquet = load_event_source(
+            "started", source="parquet", parquet_dir=parquet_dir
+        )
+        success_parquet = load_event_source(
+            "success", source="parquet", parquet_dir=parquet_dir
+        )
+        _compare_sources(started_mongo, success_mongo, started_parquet, success_parquet)
 
 
 if __name__ == "__main__":

--- a/src/run.py
+++ b/src/run.py
@@ -285,6 +285,8 @@ def _compare_sources(started_mongo, success_mongo, started_parquet, success_parq
 def plot(output_dir, drop_cutoff, source, parquet_dir, plot_type, compare_sources):
     """Generate plots using records stored in MongoDB or parquet files."""
     today = datetime.now().date().strftime("%Y%m%d")
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     source = source.lower()
     sources = ["mongo", "parquet"] if source == "both" else [source]
@@ -302,8 +304,8 @@ def plot(output_dir, drop_cutoff, source, parquet_dir, plot_type, compare_source
 
     for source_name in sources:
         suffix = "" if source_name == "mongo" and source != "both" else f"_{source_name}"
-        out_perf = os.path.join(output_dir, f"{today}_weekly{suffix}.png")
-        out_ver = os.path.join(output_dir, f"{today}_versionstream{suffix}.png")
+        out_perf = output_dir / f"{today}_weekly{suffix}.png"
+        out_ver = output_dir / f"{today}_versionstream{suffix}.png"
 
         unique_started = load_event_source(
             "started", source=source_name, parquet_dir=parquet_dir

--- a/src/viz.py
+++ b/src/viz.py
@@ -83,6 +83,11 @@ def plot_performance(
         ]
     )["id"].count()
 
+    if len(grouped_success.index) < 3:
+        raise ValueError(
+            "plot_performance requires at least 3 weekly bins to drop the first/last "
+            f"bins, but only {len(grouped_success.index)} were found."
+        )
     indexes = grouped_success.index[1:-1]
     year_index = indexes.droplevel("week")
     years = sorted(year_index.unique())

--- a/src/viz.py
+++ b/src/viz.py
@@ -13,7 +13,7 @@ from matplotlib import colors as mpl_colors
 from scipy.interpolate import RBFInterpolator
 
 plt.rcParams['font.family'] = 'sans-serif'
-plt.rcParams['font.sans-serif'] = 'Inter Tight'
+plt.rcParams['font.sans-serif'] = ['Inter Tight', 'Inter', 'Arimo', 'Liberation Sans', 'Helvetica', 'DejaVu Sans']
 
 # -----------------------------------------------------------------------------
 # Helper utilities copied from the notebook
@@ -257,7 +257,7 @@ def plot_performance(
     axes_twins[y_idx].annotate(
         f"On week {min_date[1]} of {min_date[0]}," "\nthe lowest success rate \n" f"({round(min_success[1],1)}%) was recorded.",
         xy=(min_date[1] - 0.5, round(min_success[1], 1)),
-        xytext=(xlength[-1] + 3, round(max_success[1], 1)),
+        xytext=(xlength[-1] + 20, round(max_success[1], 1)),
         xycoords="data",
         annotation_clip=False,
         color="slategray",

--- a/src/viz.py
+++ b/src/viz.py
@@ -257,7 +257,7 @@ def plot_performance(
     axes_twins[y_idx].annotate(
         f"On week {min_date[1]} of {min_date[0]}," "\nthe lowest success rate \n" f"({round(min_success[1],1)}%) was recorded.",
         xy=(min_date[1] - 0.5, round(min_success[1], 1)),
-        xytext=(xlength[-1] + 1, round(max_success[1], 1)),
+        xytext=(xlength[-1] + 3, round(max_success[1], 1)),
         xycoords="data",
         annotation_clip=False,
         color="slategray",

--- a/src/viz.py
+++ b/src/viz.py
@@ -331,8 +331,18 @@ def plot_version_stream(
     versions_started = pd.DataFrame(versions_started)
 
     versions_success = versions_success.loc[:, versions_success.sum(0) > 5000]
+    if versions_success.empty or versions_success.shape[1] == 0:
+        raise RuntimeError(
+            "plot_version_stream: no version data remaining after filter "
+            "`versions_success.sum(0) > 5000`."
+        )
 
     data = versions_success[1:-1].fillna(0.0)
+    if data.empty or data.shape[0] < 2:
+        raise RuntimeError(
+            "plot_version_stream: insufficient weekly data after slicing "
+            "`versions_success[1:-1]` for interpolation/plotting."
+        )
     xs = np.arange(len(data))
     xnew = np.linspace(0.0, len(data), num=14 * len(data))
     smoothed_data = RBFInterpolator(xs[:, np.newaxis], data.values)(xnew[:, np.newaxis])

--- a/src/viz.py
+++ b/src/viz.py
@@ -1,6 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 """Plotting utilities extracted from the analysis notebook."""
 
+from __future__ import annotations
+
 import datetime
 import calendar
 from packaging import version


### PR DESCRIPTION
### Motivation
- Allow generating plots from local parquet snapshots (named `YYYY-MM-DD-<event>.parquet`) in addition to MongoDB exports to support offline/archival workflows.
- Centralize event-frame normalization so both MongoDB and parquet loaders produce identical DataFrame shapes for plotting.
- Provide a way to compare aggregates between MongoDB and parquet sources to validate data parity.

### Description
- Add `src/data_sources.py` which implements `load_event_parquet`, parquet file discovery (`_resolve_parquet_files`), and a unified `load_event` that dispatches on `source` (`mongo` or `parquet`) and accepts `parquet_dir` and `columns` parameters.
- Introduce `normalize_event_frame` in `src/db.py` to encapsulate timestamp parsing, day truncation (`date_minus_time`) and `run_uuid` deduplication, and make `load_event` reuse it.
- Refactor CLI in `src/run.py` to use `data_sources.load_event` (aliased `load_event_source`), add `--source` (`mongo|parquet|both`), `--parquet-dir`, and `--compare-sources` options, and add helper functions `_weekly_counts` and `_compare_sources` to compare weekly aggregates between sources.

### Testing
- No automated tests exist in the repository; no test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754eddbd508330a09785b33a794030)