### PR TITLE
CHORE: add future annotations import

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -1,6 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 """Plotting utilities extracted from the analysis notebook."""
 
+from __future__ import annotations
+
 import datetime
 import calendar
 from packaging import version


### PR DESCRIPTION
### Motivation
- Enable postponed evaluation of annotations so existing union-style type hints like `str | None` remain valid without changing signatures.

### Description
- Inserted `from __future__ import annotations` at the top of `src/viz.py` (before other imports) so the `plot_performance` and `plot_version_stream` signatures using `str | None` continue to work as-is.

### Testing
- No automated tests exist in the repository and none were run; the change is a single import in `src/viz.py` and was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d77a6a508330aacae549e642cab8)