### PR TITLE
FIX: Guard version stream data length

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -331,8 +331,18 @@ def plot_version_stream(
     versions_started = pd.DataFrame(versions_started)
 
     versions_success = versions_success.loc[:, versions_success.sum(0) > 5000]
+    if versions_success.empty or versions_success.shape[1] == 0:
+        raise RuntimeError(
+            "plot_version_stream: no version data remaining after filter "
+            "`versions_success.sum(0) > 5000`."
+        )
 
     data = versions_success[1:-1].fillna(0.0)
+    if data.empty or data.shape[0] < 2:
+        raise RuntimeError(
+            "plot_version_stream: insufficient weekly data after slicing "
+            "`versions_success[1:-1]` for interpolation/plotting."
+        )
     xs = np.arange(len(data))
     xnew = np.linspace(0.0, len(data), num=14 * len(data))
     smoothed_data = RBFInterpolator(xs[:, np.newaxis], data.values)(xnew[:, np.newaxis])


### PR DESCRIPTION
### Motivation
- Avoid obscure failures from attempting to interpolate or plot when version-series data is empty or too short after filtering and slicing. 
- Provide early, descriptive errors consistent with the function's expectations and the existing filtering anchors `versions_success.sum(0) > 5000` and `versions_success[1:-1]`.

### Description
- Add a RuntimeError if `versions_success` is empty after the `versions_success.sum(0) > 5000` filter in `plot_version_stream` in `src/viz.py`.
- Add a RuntimeError if `data = versions_success[1:-1]` is empty or has fewer than two rows before performing interpolation.
- Keep existing behavior unchanged when sufficient data is present and proceed to compute `xs`, `xnew` and `smoothed_data` as before.

### Testing
- No automated tests were run because this repository contains no test suite and no CI was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d78f8a14833081aa22b9a8089ea4)