### PR TITLE
FIX: validate weekly bins before slicing

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -83,6 +83,11 @@ def plot_performance(
         ]
     )["id"].count()
 
+    if len(grouped_success.index) < 3:
+        raise ValueError(
+            "plot_performance requires at least 3 weekly bins to drop the first/last "
+            f"bins, but only {len(grouped_success.index)} were found."
+        )
     indexes = grouped_success.index[1:-1]
     year_index = indexes.droplevel("week")
     years = sorted(year_index.unique())


### PR DESCRIPTION
### Motivation
- Prevent slicing the weekly series at `indexes = grouped_success.index[1:-1]` when there are too few weekly bins, which can produce incorrect results or errors for small datasets.

### Description
- Add a guard in `plot_performance` (`src/viz.py`) that checks `len(grouped_success.index) < 3` and raises a descriptive `ValueError` if there are fewer than 3 weekly bins, placed immediately before the original slicing line.

### Testing
- No automated tests exist in the repository and no automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d795c7d08330a6b116f098797513)