### PR TITLE
FIX: Adjust min success annotation offset

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -257,7 +257,7 @@ def plot_performance(
     axes_twins[y_idx].annotate(
         f"On week {min_date[1]} of {min_date[0]}," "\nthe lowest success rate \n" f"({round(min_success[1],1)}%) was recorded.",
         xy=(min_date[1] - 0.5, round(min_success[1], 1)),
-        xytext=(xlength[-1] + 1, round(max_success[1], 1)),
+        xytext=(xlength[-1] + 3, round(max_success[1], 1)),
         xycoords="data",
         annotation_clip=False,
         color="slategray",


### PR DESCRIPTION
### Motivation
- Move the minimum success rate annotation in `plot_performance` to the right so the annotation pointer aligns closer to the percentage text and avoids overlapping the surrounding words.

### Description
- Update the `xytext` x-coordinate for the min-success annotation in `src/viz.py` (inside `plot_performance`) from `xlength[-1] + 1` to `xlength[-1] + 3` to shift the label right (`xytext=(xlength[-1] + 3, round(max_success[1], 1))`).

### Testing
- No automated tests were run for this visual/layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975dfb27cf08330b91de8d94ef0a92d)