### PR TITLE
FIX: Handle Z timestamps in export date parsing

### DIFF
--- a/scripts/export_daily_parquet.py
+++ b/scripts/export_daily_parquet.py
@@ -62,7 +62,13 @@ def _coerce_datetime(value: datetime | date | str) -> datetime:
         return value
     if isinstance(value, date):
         return datetime.combine(value, time.min)
-    return datetime.fromisoformat(value)
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return datetime.combine(date.fromisoformat(normalized), time.min)
 
 
 def _normalize_timestamp(value: datetime | date | str, tz: ZoneInfo) -> datetime:


### PR DESCRIPTION
### Motivation
- Parsing of MongoDB `dateCreated` ISO strings with a trailing `Z` raised a `ValueError` and caused the exporter to fail when determining date bounds.

### Description
- Normalize trailing `Z` timestamps in `scripts/export_daily_parquet.py` by converting `...Z` to `...+00:00` in `_coerce_datetime`, parse with `datetime.fromisoformat`, and fall back to date-only parsing to produce a `datetime`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975eec6422c8330a72c7060290920a6)