### PR TITLE
FEAT: Default to parquet sources and opt-in MongoDB

### DIFF
--- a/scripts/update_plots.sh
+++ b/scripts/update_plots.sh
@@ -19,6 +19,7 @@ if [[ -z "$PARQUET_DIR" ]]; then
 fi
 
 PARQUET_DIR="$(cd "$PARQUET_DIR" && pwd)"
+# Keep absolute path since we later cd into the repo root before plotting.
 
 git clone "$REPO_URL" "$TMP_REPO"
 

--- a/scripts/update_plots.sh
+++ b/scripts/update_plots.sh
@@ -18,6 +18,8 @@ if [[ -z "$PARQUET_DIR" ]]; then
     exit 2
 fi
 
+PARQUET_DIR="$(cd "$PARQUET_DIR" && pwd)"
+
 git clone "$REPO_URL" "$TMP_REPO"
 
 ASSETS_DIR="$TMP_REPO/docs/assets"

--- a/scripts/update_plots.sh
+++ b/scripts/update_plots.sh
@@ -5,12 +5,18 @@
 set -euo pipefail
 
 REPO_URL="${1:-git@github.com:nipreps/nipreps.github.io.git}"
+PARQUET_DIR="${2:-${PARQUET_DIR:-}}"
 TMP_REPO="$(mktemp -d)"
 
 cleanup() {
     rm -rf "$TMP_REPO"
 }
 trap cleanup EXIT
+
+if [[ -z "$PARQUET_DIR" ]]; then
+    echo "ERROR: PARQUET_DIR is required (pass as arg 2 or set PARQUET_DIR)." >&2
+    exit 2
+fi
 
 git clone "$REPO_URL" "$TMP_REPO"
 
@@ -20,7 +26,10 @@ mkdir -p "$ASSETS_DIR"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-$( which conda ) run -n base python src/run.py plot -o "$ASSETS_DIR"
+$( which conda ) run -n base python src/run.py plot \
+    --source parquet \
+    --parquet-dir "$PARQUET_DIR" \
+    -o "$ASSETS_DIR"
 
 cd "$TMP_REPO"
 git pull --ff-only
@@ -31,4 +40,3 @@ if ! git diff --cached --quiet; then
 else
     echo "No changes to commit."
 fi
-

--- a/src/run.py
+++ b/src/run.py
@@ -105,7 +105,7 @@ def _sanitize_event_name(event_name):
 @click.option(
     "--store",
     type=click.Choice(["mongo", "parquet"], case_sensitive=False),
-    default="mongo",
+    default="parquet",
     show_default=True,
     help="Store fetched records in MongoDB or as parquet files.",
 )
@@ -255,7 +255,7 @@ def _compare_sources(started_mongo, success_mongo, started_parquet, success_parq
 @click.option(
     "--source",
     type=click.Choice(["mongo", "parquet", "both"], case_sensitive=False),
-    default="mongo",
+    default="parquet",
     show_default=True,
     help="Data source to use for plots.",
 )


### PR DESCRIPTION
### Motivation
- Move the default data flow to parquet snapshots to make plotting and downstream consumption parquet-first and reduce implicit reliance on a live MongoDB instance.
- Prevent accidental MongoDB reads/writes during a migration by gating MongoDB operations behind an explicit opt-in feature flag.
- Update automation and documentation so scheduled jobs and users explicitly provide parquet paths and are aware of parity/retention risks.

### Description
- Change CLI defaults in `src/run.py` so `--store` defaults to `parquet` for `get` and `--source` defaults to `parquet` for `plot`, preserving existing parquet validation for `--parquet-dir`.
- Add an environment-driven feature flag `FMRIPREP_STATS_ENABLE_MONGO` in `src/db.py` and require it for `mongo_id_lookup`, `store_events`, and `load_event`, raising a `RuntimeError` when MongoDB access is attempted while disabled.
- Update the automation script `scripts/update_plots.sh` to require a `PARQUET_DIR` (as arg 2 or `PARQUET_DIR` env var) and to invoke `src/run.py plot --source parquet --parquet-dir <dir>`.
- Update `README.md` examples and cron line to document the parquet-first workflow, show how to enable MongoDB with `FMRIPREP_STATS_ENABLE_MONGO=1`, and call out parity/retention caution before disabling MongoDB.

### Testing
- No automated tests exist in this repository and no CI-based tests were executed for this change.
- Changes were validated by inspecting the updated callsites and files (`src/run.py`, `src/db.py`, `scripts/update_plots.sh`, `README.md`) and ensuring the CLI option logic and script invocation match the new defaults.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770a3781948330ae8391f8cb881917)