### PR TITLE
FIX: use refresh-token Dropbox auth for plot workflow

### DIFF
--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -1,0 +1,86 @@
+name: Update plots
+
+on:
+  schedule:
+    - cron: "0 22 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  build-plots:
+    runs-on: ubuntu-latest
+    env:
+      PARQUET_DIR: /tmp/parquet
+      PLOTS_DIR: /tmp/plots
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Cache parquet downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PARQUET_DIR }}
+          key: parquet-${{ runner.os }}-${{ github.ref_name }}-v1
+          restore-keys: |
+            parquet-${{ runner.os }}-${{ github.ref_name }}-
+
+      - name: Download parquet from Dropbox
+        env:
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+          DROPBOX_APP_REFRESH_TOKEN: ${{ secrets.DROPBOX_APP_REFRESH_TOKEN }}
+          DROPBOX_PARQUET_PATH: ${{ secrets.DROPBOX_PARQUET_PATH }}
+        run: |
+          python scripts/dropbox_parquet_sync.py \
+            --parquet-dir "${PARQUET_DIR}" \
+            --dropbox-path "${DROPBOX_PARQUET_PATH}" \
+            --app-key "${DROPBOX_APP_KEY}" \
+            --app-secret "${DROPBOX_APP_SECRET}" \
+            --refresh-token "${DROPBOX_APP_REFRESH_TOKEN}"
+
+      - name: Generate plots
+        run: |
+          python src/run.py plot \
+            --source parquet \
+            --parquet-dir "${PARQUET_DIR}" \
+            -o "${PLOTS_DIR}"
+
+      - name: Upload plots artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-plots
+          path: ${{ env.PLOTS_DIR }}
+          retention-days: 7
+
+  publish-plots:
+    runs-on: ubuntu-latest
+    needs: build-plots
+    env:
+      PLOTS_DIR: /tmp/plots
+    steps:
+      - name: Download plots artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: weekly-plots
+          path: ${{ env.PLOTS_DIR }}
+
+      - name: Upload plots to Dropbox
+        env:
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+          DROPBOX_APP_REFRESH_TOKEN: ${{ secrets.DROPBOX_APP_REFRESH_TOKEN }}
+          DROPBOX_PLOTS_PATH: ${{ secrets.DROPBOX_PLOTS_PATH }}
+        run: |
+          python scripts/dropbox_upload_plots.py \
+            --plots-dir "${PLOTS_DIR}" \
+            --dropbox-path "${DROPBOX_PLOTS_PATH}" \
+            --app-key "${DROPBOX_APP_KEY}" \
+            --app-secret "${DROPBOX_APP_SECRET}" \
+            --refresh-token "${DROPBOX_APP_REFRESH_TOKEN}"

--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -65,6 +65,9 @@ jobs:
     env:
       PLOTS_DIR: /tmp/plots
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download plots artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -1,0 +1,86 @@
+name: Update plots
+
+on:
+  schedule:
+    - cron: "0 22 * * 1"
+  workflow_dispatch:
+
+jobs:
+  build-plots:
+    runs-on: ubuntu-latest
+    env:
+      PARQUET_DIR: /tmp/parquet
+      PLOTS_DIR: /tmp/plots
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Cache parquet downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PARQUET_DIR }}
+          key: parquet-${{ runner.os }}-${{ github.ref_name }}-v1
+          restore-keys: |
+            parquet-${{ runner.os }}-${{ github.ref_name }}-
+
+      - name: Download parquet from Dropbox
+        env:
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+          DROPBOX_APP_REFRESH_TOKEN: ${{ secrets.DROPBOX_APP_REFRESH_TOKEN }}
+          DROPBOX_PARQUET_PATH: ${{ secrets.DROPBOX_PARQUET_PATH }}
+        run: |
+          python scripts/dropbox_parquet_sync.py \
+            --parquet-dir "${PARQUET_DIR}" \
+            --dropbox-path "${DROPBOX_PARQUET_PATH}" \
+            --app-key "${DROPBOX_APP_KEY}" \
+            --app-secret "${DROPBOX_APP_SECRET}" \
+            --refresh-token "${DROPBOX_APP_REFRESH_TOKEN}"
+
+      - name: Generate plots
+        run: |
+          python src/run.py plot \
+            --source parquet \
+            --parquet-dir "${PARQUET_DIR}" \
+            -o "${PLOTS_DIR}"
+
+      - name: Upload plots artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-plots
+          path: ${{ env.PLOTS_DIR }}
+          retention-days: 7
+
+  publish-plots:
+    runs-on: ubuntu-latest
+    needs: build-plots
+    env:
+      PLOTS_DIR: /tmp/plots
+    steps:
+      - name: Download plots artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: weekly-plots
+          path: ${{ env.PLOTS_DIR }}
+
+      - name: Upload plots to Dropbox
+        env:
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+          DROPBOX_APP_REFRESH_TOKEN: ${{ secrets.DROPBOX_APP_REFRESH_TOKEN }}
+          DROPBOX_PLOTS_PATH: ${{ secrets.DROPBOX_PLOTS_PATH }}
+        run: |
+          python scripts/dropbox_upload_plots.py \
+            --plots-dir "${PLOTS_DIR}" \
+            --dropbox-path "${DROPBOX_PLOTS_PATH}" \
+            --app-key "${DROPBOX_APP_KEY}" \
+            --app-secret "${DROPBOX_APP_SECRET}" \
+            --refresh-token "${DROPBOX_APP_REFRESH_TOKEN}"

--- a/scripts/dropbox_parquet_sync.py
+++ b/scripts/dropbox_parquet_sync.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Sync parquet files from Dropbox using refresh-token auth."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+
+def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
+    response = requests.post(
+        "https://api.dropboxapi.com/oauth2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": app_key,
+            "client_secret": app_secret,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload["access_token"]
+
+
+def list_folder_entries(access_token: str, path: str) -> Iterable[dict]:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    entries = []
+    payload = {"path": path}
+    url = "https://api.dropboxapi.com/2/files/list_folder"
+
+    while True:
+        response = requests.post(url, headers=headers, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        entries.extend(data.get("entries", []))
+        if data.get("has_more"):
+            payload = {"cursor": data["cursor"]}
+            url = "https://api.dropboxapi.com/2/files/list_folder/continue"
+        else:
+            break
+
+    return entries
+
+
+def download_file(access_token: str, dropbox_path: str, destination: Path) -> None:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Dropbox-API-Arg": json.dumps({"path": dropbox_path}),
+    }
+    response = requests.post(
+        "https://content.dropboxapi.com/2/files/download",
+        headers=headers,
+        timeout=300,
+    )
+    response.raise_for_status()
+    destination.write_bytes(response.content)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync parquet files from Dropbox")
+    parser.add_argument("--parquet-dir", required=True, help="Local parquet directory")
+    parser.add_argument("--dropbox-path", required=True, help="Dropbox folder path")
+    parser.add_argument("--app-key", required=True, help="Dropbox app key")
+    parser.add_argument("--app-secret", required=True, help="Dropbox app secret")
+    parser.add_argument("--refresh-token", required=True, help="Dropbox refresh token")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    parquet_dir = Path(args.parquet_dir)
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    dropbox_path = args.dropbox_path.rstrip("/")
+
+    access_token = get_access_token(args.app_key, args.app_secret, args.refresh_token)
+    entries = list_folder_entries(access_token, dropbox_path)
+
+    for entry in entries:
+        if entry.get(".tag") != "file":
+            continue
+        dropbox_file = entry["path_lower"]
+        rel_path = entry["path_display"][len(dropbox_path) :].lstrip("/")
+        local_path = parquet_dir / rel_path
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_size = entry.get("size")
+        if local_path.exists() and expected_size and local_path.stat().st_size == expected_size:
+            continue
+        download_file(access_token, dropbox_file, local_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dropbox_upload_plots.py
+++ b/scripts/dropbox_upload_plots.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Upload plot artifacts to Dropbox using refresh-token auth."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import requests
+
+
+def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
+    response = requests.post(
+        "https://api.dropboxapi.com/oauth2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": app_key,
+            "client_secret": app_secret,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload["access_token"]
+
+
+def upload_file(access_token: str, dropbox_path: str, file_path: Path) -> None:
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Dropbox-API-Arg": json.dumps({"path": dropbox_path, "mode": "overwrite", "mute": True}),
+        "Content-Type": "application/octet-stream",
+    }
+    response = requests.post(
+        "https://content.dropboxapi.com/2/files/upload",
+        headers=headers,
+        data=file_path.read_bytes(),
+        timeout=300,
+    )
+    response.raise_for_status()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Upload plots to Dropbox")
+    parser.add_argument("--plots-dir", required=True, help="Local plots directory")
+    parser.add_argument("--dropbox-path", required=True, help="Dropbox destination path")
+    parser.add_argument("--app-key", required=True, help="Dropbox app key")
+    parser.add_argument("--app-secret", required=True, help="Dropbox app secret")
+    parser.add_argument("--refresh-token", required=True, help="Dropbox refresh token")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    plots_dir = Path(args.plots_dir)
+    dropbox_base = args.dropbox_path.rstrip("/")
+
+    access_token = get_access_token(args.app_key, args.app_secret, args.refresh_token)
+
+    for file_path in plots_dir.rglob("*"):
+        if file_path.is_dir():
+            continue
+        rel_path = file_path.relative_to(plots_dir).as_posix()
+        dropbox_path = f"{dropbox_base}/{rel_path}"
+        upload_file(access_token, dropbox_path, file_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Remove fragile inline Python in the workflow and make Dropbox interactions testable and maintainable by moving logic into standalone scripts.
- Use Dropbox OAuth refresh-token flow instead of a single long-lived access token to avoid auth expiration and improve security by relying on `DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, and `DROPBOX_APP_REFRESH_TOKEN` secrets.
- Avoid unnecessary full re-downloads and rate-limit pressure by performing size-based delta checks and leveraging a cached parquet directory.

### Description
- Add `scripts/dropbox_parquet_sync.py` which exchanges a refresh token for an access token, lists files via `files/list_folder`, and downloads changed parquet files using size comparisons to skip unchanged files.
- Add `scripts/dropbox_upload_plots.py` which exchanges a refresh token for an access token and uploads plot files to Dropbox with `files/upload` using `mode: overwrite`.
- Update `.github/workflows/update-plots.yml` to remove inline Python blocks and call the new scripts, passing `DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, `DROPBOX_APP_REFRESH_TOKEN`, and path secrets, while keeping the artifact handoff and plot generation steps intact.

### Testing
- No automated tests were executed for these changes because they are workflow and helper-script updates that require CI secrets and live Dropbox access.
- Recommend running the workflow in a controlled environment or adding unit tests for `scripts/dropbox_parquet_sync.py` and `scripts/dropbox_upload_plots.py` before relying on scheduled runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770a5dc3f08330b5f55b856f32ecc2)