### PR TITLE
CI: store parquet artifact in weekly workflow

### DIFF
--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -52,6 +52,13 @@ jobs:
             --parquet-dir "${PARQUET_DIR}" \
             -o "${PLOTS_DIR}"
 
+      - name: Upload parquet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-parquet
+          path: ${{ env.PARQUET_DIR }}
+          retention-days: 7
+
       - name: Upload plots artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Motivation
- Preserve the downloaded/generated parquet data from the weekly plots workflow so parquet inputs are available for debugging and reuse outside the run.

### Description
- Updated `.github/workflows/update-plots.yml` to add an `Upload parquet artifact` step that uses `actions/upload-artifact@v4` to upload `${{ env.PARQUET_DIR }}` as `weekly-parquet` with `retention-days: 7`.

### Testing
- No automated tests were run for this change because it only modifies the GitHub Actions workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774c4006bc8330ad8b37428b9f244c)