### PR TITLE
ENH: surface Dropbox sync errors and continue past per-file failures

### DIFF
--- a/scripts/dropbox_parquet_sync.py
+++ b/scripts/dropbox_parquet_sync.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from pathlib import Path
 from typing import Iterable
 
 import requests
+
+LOG = logging.getLogger("dropbox_parquet_sync")
 
 
 def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
@@ -59,7 +62,13 @@ def download_file(access_token: str, dropbox_path: str, destination: Path) -> No
         headers=headers,
         timeout=300,
     )
-    response.raise_for_status()
+    if not response.ok:
+        # Surface Dropbox's specific error tag (e.g. path/not_found) which lives
+        # in the JSON body — raise_for_status() alone hides it.
+        raise requests.exceptions.HTTPError(
+            f"{response.status_code} for {dropbox_path}: {response.text or '<empty>'}",
+            response=response,
+        )
     destination.write_bytes(response.content)
 
 
@@ -86,7 +95,10 @@ def write_metadata(metadata_path: Path, metadata: dict[str, dict[str, str | int]
     metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def main() -> None:
+def main() -> int:
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO
+    )
     args = parse_args()
     parquet_dir = Path(args.parquet_dir)
     parquet_dir.mkdir(parents=True, exist_ok=True)
@@ -95,7 +107,13 @@ def main() -> None:
     cached_metadata = load_metadata(metadata_path)
 
     access_token = get_access_token(args.app_key, args.app_secret, args.refresh_token)
-    entries = list_folder_entries(access_token, dropbox_path)
+    entries = list(list_folder_entries(access_token, dropbox_path))
+    LOG.info(
+        "Listed %d entries at Dropbox path %r", len(entries), dropbox_path or "/"
+    )
+
+    fetched = skipped = failed = 0
+    failures: list[tuple[str, str]] = []
 
     for entry in entries:
         if entry.get(".tag") != "file":
@@ -108,15 +126,45 @@ def main() -> None:
         expected_size = entry.get("size")
         cached_entry = cached_metadata.get(dropbox_file, {})
         if local_path.exists() and expected_rev and cached_entry.get("rev") == expected_rev:
+            skipped += 1
             continue
-        download_file(access_token, dropbox_file, local_path)
+        try:
+            download_file(access_token, dropbox_file, local_path)
+        except requests.exceptions.HTTPError as exc:
+            failed += 1
+            failures.append((dropbox_file, str(exc)))
+            LOG.error("download FAILED for %s: %s", dropbox_file, exc)
+            continue
         cached_metadata[dropbox_file] = {
             "rev": expected_rev or "",
             "size": expected_size or 0,
         }
+        fetched += 1
+        if fetched % 100 == 0:
+            LOG.info(
+                "progress: fetched=%d skipped=%d failed=%d",
+                fetched,
+                skipped,
+                failed,
+            )
 
     write_metadata(metadata_path, cached_metadata)
 
+    LOG.info(
+        "summary: fetched=%d skipped(cached)=%d failed=%d",
+        fetched,
+        skipped,
+        failed,
+    )
+    if failures:
+        LOG.error("download failures (%d):", len(failures))
+        for path, msg in failures[:25]:
+            LOG.error("  %s -> %s", path, msg)
+        if len(failures) > 25:
+            LOG.error("  ... and %d more", len(failures) - 25)
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `scripts/dropbox_parquet_sync.py` aborted on the **first** Dropbox 409
  with no indication of which file failed (response body was dropped by
  `raise_for_status()`), so the recent `update-plots.yml` failures
  ([run 25385044925](https://github.com/nipreps/fmriprep_stats/actions/runs/25385044925/job/74443679351)) only show
  `409 Conflict for url: .../files/download` and we cannot tell which
  parquet caused it.
- Aborting on a single failure also throws away ~thousands of
  successfully-listable downloads, so the downstream plot job has
  nothing to work with even when most files are fine.

## Changes

- `download_file`: include the failing Dropbox path **and the response
  body** in the raised `HTTPError`. Dropbox returns the specific tag
  (`path/not_found`, `path/restricted_content`, ...) in the JSON body —
  surfacing it lets us diagnose the offender from CI logs.
- `main`: per-file `try/except`. Log each failure, continue, persist
  the cache metadata for successful downloads, and exit non-zero only
  if any file failed (so CI still flags it).
- `INFO`-level progress every 100 fetches; final summary lists up to 25
  failed paths with their Dropbox error tags.

## Test plan

- [x] Local smoke import (`python -c "import dropbox_parquet_sync"`).
- [ ] Re-run `update-plots.yml` after merge; the next failure (if any)
  will identify the specific file(s) and Dropbox error tag.
- [ ] If the run succeeds (i.e. the 409 was transient), close the loop
  and consider any further hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)