### PR TITLE
FIX: make weekly aggregation in viz calendar-aware

### DIFF
--- a/scripts/weekly_gap_audit.py
+++ b/scripts/weekly_gap_audit.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""List ISO weeks with zero events for each tracked event type.
+
+Reads the parquet directory produced by the daily Sentry-fetch action,
+groups events by ISO (year, week), and reports every Monday-anchored week
+between the earliest and latest event for which the loaded DataFrame has
+no rows. Prints a deterministic, line-oriented summary so it can be
+diff'd across runs and pasted into PR descriptions.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from data_sources import load_event_parquet  # noqa: E402
+
+
+def expected_weekly_index(start: pd.Timestamp, end: pd.Timestamp) -> pd.MultiIndex:
+    mondays = pd.date_range(
+        start - pd.Timedelta(days=int(start.weekday())),
+        end,
+        freq="W-MON",
+    )
+    iso = mondays.isocalendar()
+    return pd.MultiIndex.from_arrays(
+        [iso.year.astype("int64"), iso.week.astype("int64")],
+        names=["year", "week"],
+    )
+
+
+def audit(parquet_dir: str, events=("started", "success", "failed")) -> int:
+    rc = 0
+    for ev in events:
+        df = load_event_parquet(ev, parquet_dir, unique=True)
+        iso = df["date_minus_time"].dt.isocalendar()
+        observed = pd.MultiIndex.from_arrays(
+            [iso["year"].astype("int64").values, iso["week"].astype("int64").values],
+            names=["year", "week"],
+        ).unique()
+        full = expected_weekly_index(
+            df["date_minus_time"].min(), df["date_minus_time"].max()
+        )
+        missing = full.difference(observed)
+        print(
+            f"[{ev}] expected_weeks={len(full)} observed_weeks={len(observed)} "
+            f"missing={len(missing)} "
+            f"range={df['date_minus_time'].min().date()}..{df['date_minus_time'].max().date()}"
+        )
+        for y, w in sorted(missing):
+            iso_monday = pd.Timestamp.fromisocalendar(int(y), int(w), 1).date()
+            print(f"  {ev}  {int(y)}-W{int(w):02d}  (week starting {iso_monday})")
+        if len(missing):
+            rc = 1
+    return rc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parquet-dir", required=True, help="Directory of *-<event>.parquet files")
+    args = parser.parse_args()
+    return audit(args.parquet_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/viz.py
+++ b/src/viz.py
@@ -31,6 +31,30 @@ def _parse(vstr):
 _vparse = np.vectorize(_parse)
 
 
+def _full_weekly_index(*date_series: pd.Series) -> pd.MultiIndex:
+    """Calendar-complete ISO ``(year, week)`` index from min..max of inputs.
+
+    Weeks with zero events would otherwise be dropped by groupby and the
+    plot would paint adjacent non-empty weeks side-by-side, hiding any
+    calendar-time gap. Reindexing weekly counts against this index keeps
+    those weeks present (as zero) so the bar/line plots stay calendar-faithful.
+    """
+    bounds = pd.concat([s.dropna() for s in date_series])
+    if bounds.empty:
+        return pd.MultiIndex.from_tuples([], names=["year", "week"])
+    start, end = bounds.min(), bounds.max()
+    mondays = pd.date_range(
+        start - pd.Timedelta(days=int(start.weekday())),
+        end,
+        freq="W-MON",
+    )
+    iso = mondays.isocalendar()
+    return pd.MultiIndex.from_arrays(
+        [iso.year.astype("int64"), iso.week.astype("int64")],
+        names=["year", "week"],
+    )
+
+
 # -----------------------------------------------------------------------------
 # Plotting functions
 # -----------------------------------------------------------------------------
@@ -90,21 +114,36 @@ def plot_performance(
             "plot_performance requires at least 3 weekly bins to drop the first/last "
             f"bins, but only {len(grouped_success.index)} were found."
         )
+
+    full = _full_weekly_index(
+        unique_started["date_minus_time"], unique_success["date_minus_time"]
+    )
+    grouped_started = grouped_started.reindex(full, fill_value=0)
+    grouped_success = grouped_success.reindex(full, fill_value=0)
+    grouped_started_success = grouped_started_success.reindex(full, fill_value=0)
+
     indexes = grouped_success.index[1:-1]
     year_index = indexes.droplevel("week")
     years = sorted(year_index.unique())
     weeks_per_year = [(year_index == yr).sum() for yr in years]
 
-    success_data = grouped_success[indexes]
-    started_data = grouped_started[indexes]
+    started_data = grouped_started.loc[indexes]
+    success_data = grouped_success.loc[indexes]
 
-    abs_success_mean = success_data.values.mean()
-    success_ratio = 100 * success_data / started_data
-    success_mean = success_ratio.values.mean()
-    max_success = (np.argmax(success_ratio), success_ratio.values.max())
-    max_date = indexes[max_success[0]]
-    min_success = (np.argmin(success_ratio), success_ratio.values.min())
-    min_date = indexes[min_success[0]]
+    real = started_data > 0
+    if not real.any():
+        raise ValueError("plot_performance: no weeks with started>0 after reindex.")
+
+    abs_success_mean = success_data[real].mean()
+    success_ratio = pd.Series(np.nan, index=indexes, dtype=float)
+    success_ratio[real] = 100.0 * success_data[real] / started_data[real]
+    success_mean = float(np.nanmean(success_ratio.values))
+    max_idx = int(np.nanargmax(success_ratio.values))
+    max_success = (max_idx, float(success_ratio.iloc[max_idx]))
+    max_date = indexes[max_idx]
+    min_idx = int(np.nanargmin(success_ratio.values))
+    min_success = (min_idx, float(success_ratio.iloc[min_idx]))
+    min_date = indexes[min_idx]
 
     plt.clf()
     fig, axes = plt.subplots(
@@ -213,7 +252,7 @@ def plot_performance(
     axes[-1].annotate(
         "fMRIPrep averaged" f" {int(round(abs_success_mean, -2))}"
         "\nweekly successful runs,\n"
-        f" out of {int(round(grouped_started.values[1:-1].mean(), -2))} runs/week.",
+        f" out of {int(round(started_data[real].mean(), -2))} runs/week.",
         xy=(0 - sum(xlength[:-1]), abs_success_mean),
         xytext=(xlength[-1] + 1, abs_success_mean),
         xycoords="data",
@@ -227,7 +266,7 @@ def plot_performance(
     ).set_zorder(0)
 
     axes_twins[-1].annotate(
-        "Averaged weekly success\n" f"rate was {round(success_mean,1)}±{round(success_ratio.values.std(),0)}%.",
+        "Averaged weekly success\n" f"rate was {round(success_mean,1)}±{round(float(np.nanstd(success_ratio.values)),0)}%.",
         xy=(0 - sum(xlength[:-1]), success_mean),
         xytext=(xlength[-1] + 1, success_mean),
         xycoords="data",
@@ -305,12 +344,10 @@ def plot_version_stream(
         unique_success["run_uuid"].isin(unique_started["run_uuid"])
     ]
 
-    indexes = unique_started_success.groupby(
-        [
-            unique_started_success["date_minus_time"].dt.isocalendar().year,
-            unique_started_success["date_minus_time"].dt.isocalendar().week,
-        ]
-    )["id"].count().index
+    full = _full_weekly_index(
+        unique_started["date_minus_time"], unique_success["date_minus_time"]
+    )
+    indexes = full
     year_index = indexes.droplevel("week")
     years = sorted(year_index.unique())
     weeks_per_year = [(year_index == yr).sum() for yr in years]
@@ -334,8 +371,8 @@ def plot_version_stream(
             ]
         )["id"].count()
 
-    versions_success = pd.DataFrame(versions_success)
-    versions_started = pd.DataFrame(versions_started)
+    versions_success = pd.DataFrame(versions_success).reindex(full, fill_value=0.0)
+    versions_started = pd.DataFrame(versions_started).reindex(full, fill_value=0.0)
 
     versions_success = versions_success.loc[:, versions_success.sum(0) > 5000]
     if versions_success.empty or versions_success.shape[1] == 0:


### PR DESCRIPTION
## Summary

`src/viz.py` groups events by ISO `(year, week)` and plots bars at `np.arange(len(weeks))` — so any week with zero rows is **silently dropped from the groupby**, the next non-empty week paints adjacent to the previous, and calendar-time gaps disappear from the figure.

This is what produced the "the backfill didn't change anything" puzzle: the post-backfill PNG (with `2026-W14` and `W15` newly populated) looked nearly identical to the pre-backfill PNG in late March / early April because the bars in that region just shifted right by two slots — same magnitude, different calendar position.

## Changes

- New `scripts/weekly_gap_audit.py` — lists every `(iso_year, iso_week)` with **zero events** between min..max of each tracked event series. Deterministic line-oriented output, easy to diff and paste into PRs.
- `src/viz.py`:
  - New module-level helper `_full_weekly_index(*date_series)` returning a Monday-anchored full ISO `(year, week)` `MultiIndex` covering the data range.
  - `plot_performance` and `plot_version_stream` now reindex their weekly counts against `_full_weekly_index` with `fill_value=0`. Missing weeks paint as zero-height bars; the success-rate line plots NaN there so matplotlib breaks the line.
  - Summary statistics in `plot_performance` (mean, std, argmax/argmin, "averaged X weekly successful runs / Y runs/week") are now computed on a `real = started > 0` mask using `np.nanmean`/`np.nanstd`/`np.nanargmax` — so zero-fill weeks don't dilute averages.

## Audit on current data (`update-plots.yml` cache)

```
[started] expected_weeks=192 observed_weeks=192 missing=0 range=2022-09-09..2026-05-04
[success] expected_weeks=192 observed_weeks=192 missing=0 range=2022-09-09..2026-05-04
[failed]  expected_weeks=192 observed_weeks=192 missing=0 range=2022-09-09..2026-05-04
```

So the post-backfill series has no current gaps — this fix is preventive (any future Sentry-fetch suspension will show up immediately) and corrective (calendar-faithful axis even when complete).

## Verification

- **Baseline render on current data**: byte-identical to the patched render. Confirmed via `cmp` on both PNGs. With no gaps the fix is a no-op visually — exactly the right behavior.
- **Synthetic gap test**: removed `2026-03-30..2026-04-12` (14 days, ISO weeks 14+15 of 2026), re-rendered with both versions:
  - Baseline collapses the gap; the right-hand region of 2026 looks continuous.
  - Patched render shows two zero-height bars at the gap, a break in the success-rate line, and a visible pinch in the version-stream stackplot.
  - Annotation values (averaged 66.7% success, 10100/14900 runs/week) are identical to the gap-free render — confirming the `real` mask correctly excludes zero-fills from stats.

## Test plan

- [x] Local smoke import + audit on GHA parquet cache.
- [x] Byte-equality on current data (no missing weeks).
- [x] Synthetic-gap check (visible gap in patched, hidden in baseline).
- [ ] Trigger `update-plots.yml` post-merge; confirm the rendered PNG is unchanged on the production data (no gaps right now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)