### PR TITLE
FEAT: publish weekly plots as GitHub release assets (also keepalive)

### DIFF
--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -124,3 +124,99 @@ jobs:
             --app-key "${DROPBOX_APP_KEY}" \
             --app-secret "${DROPBOX_APP_SECRET}" \
             --refresh-token "${DROPBOX_APP_REFRESH_TOKEN}"
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: build-plots
+    permissions:
+      contents: write
+    env:
+      PLOTS_DIR: /tmp/plots
+      # Keep this many most-recent weekly-* releases; older ones are pruned
+      # along with their tags. Bump up if the website ever needs deeper history.
+      RETENTION: 26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download plots artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: weekly-plots
+          path: ${{ env.PLOTS_DIR }}
+
+      - name: Stage stable-named copies
+        run: |
+          set -e
+          DATE=$(date -u +%Y-%m-%d)
+          ls "${PLOTS_DIR}"
+          # The CLI prefixes outputs with today's date; copy to stable names so
+          # the latest-release URL (.../releases/latest/download/<asset>) is
+          # constant for downstream consumers (nipreps.org).
+          cp "${PLOTS_DIR}/${DATE}_weekly_parquet.png"        "${PLOTS_DIR}/weekly.png"
+          cp "${PLOTS_DIR}/${DATE}_versionstream_parquet.png" "${PLOTS_DIR}/versionstream.png"
+          {
+            echo "DATE=${DATE}"
+            echo "TAG=weekly-${DATE}"
+            echo "ISO_WEEK=$(date -u +%G-W%V)"
+          } >> "$GITHUB_ENV"
+
+      - name: Heartbeat commit (resets repo-inactivity clock)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Scheduled workflows are auto-disabled after ~60 days without
+          # repository activity. A weekly file touch guarantees activity even
+          # if no human commit landed in that window.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdir -p .github
+          echo "${DATE}" > .github/last_weekly_run.txt
+          git add .github/last_weekly_run.txt
+          if git diff --cached --quiet; then
+            echo "No heartbeat change to commit (already at ${DATE})."
+          else
+            git commit -m "chore: weekly heartbeat ${DATE}"
+            git push origin HEAD:master
+          fi
+
+      - name: Create or update weekly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} exists; replacing assets."
+            gh release upload "${TAG}" --clobber \
+              "${PLOTS_DIR}/weekly.png" \
+              "${PLOTS_DIR}/versionstream.png"
+          else
+            gh release create "${TAG}" \
+              --title "Weekly stats — ${DATE} (${ISO_WEEK})" \
+              --notes "Automated weekly snapshot of fMRIPrep usage stats.
+
+          Stable URLs (always point at the most recent release):
+
+          - https://github.com/${{ github.repository }}/releases/latest/download/weekly.png
+          - https://github.com/${{ github.repository }}/releases/latest/download/versionstream.png" \
+              "${PLOTS_DIR}/weekly.png" \
+              "${PLOTS_DIR}/versionstream.png"
+          fi
+
+      - name: Prune old weekly releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Keep the RETENTION newest weekly-YYYY-MM-DD releases; delete the rest
+          # (including their orphaned tags). Idempotent: no-op when count<=RETENTION.
+          gh release list --limit 200 \
+            --json tagName \
+            --jq '.[] | select(.tagName | startswith("weekly-")) | .tagName' \
+            | sort -r \
+            | tail -n +$((RETENTION + 1)) \
+            | while read -r tag; do
+                echo "Pruning old release ${tag}"
+                gh release delete "${tag}" --cleanup-tag --yes
+              done

--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -151,15 +151,20 @@ jobs:
       - name: Stage stable-named copies
         run: |
           set -e
+          # src/run.py prefixes plot files with strftime("%Y%m%d") (no
+          # separators), e.g. 20260506_weekly_parquet.png. Tags and human
+          # labels use the ISO YYYY-MM-DD form. Keep both.
           DATE=$(date -u +%Y-%m-%d)
+          STAMP=$(date -u +%Y%m%d)
           ls "${PLOTS_DIR}"
-          # The CLI prefixes outputs with today's date; copy to stable names so
-          # the latest-release URL (.../releases/latest/download/<asset>) is
-          # constant for downstream consumers (nipreps.org).
-          cp "${PLOTS_DIR}/${DATE}_weekly_parquet.png"        "${PLOTS_DIR}/weekly.png"
-          cp "${PLOTS_DIR}/${DATE}_versionstream_parquet.png" "${PLOTS_DIR}/versionstream.png"
+          # Stable names so the latest-release URL
+          # (.../releases/latest/download/<asset>) is constant for downstream
+          # consumers (nipreps.org).
+          cp "${PLOTS_DIR}/${STAMP}_weekly_parquet.png"        "${PLOTS_DIR}/weekly.png"
+          cp "${PLOTS_DIR}/${STAMP}_versionstream_parquet.png" "${PLOTS_DIR}/versionstream.png"
           {
             echo "DATE=${DATE}"
+            echo "STAMP=${STAMP}"
             echo "TAG=weekly-${DATE}"
             echo "ISO_WEEK=$(date -u +%G-W%V)"
           } >> "$GITHUB_ENV"
@@ -167,6 +172,7 @@ jobs:
       - name: Heartbeat commit (resets repo-inactivity clock)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Scheduled workflows are auto-disabled after ~60 days without
           # repository activity. A weekly file touch guarantees activity even
@@ -180,7 +186,7 @@ jobs:
             echo "No heartbeat change to commit (already at ${DATE})."
           else
             git commit -m "chore: weekly heartbeat ${DATE}"
-            git push origin HEAD:master
+            git push origin "HEAD:${DEFAULT_BRANCH}"
           fi
 
       - name: Create or update weekly release


### PR DESCRIPTION
## Summary

Solves two problems in one change:

1. **Website integration** — nipreps.org currently has no automated path to fetch the weekly plots; the previous bridge was the legacy `scripts/update_plots.sh` (local cron, status unclear). After this PR, every Monday produces a `weekly-YYYY-MM-DD` GitHub release whose assets are the two PNGs under stable names. nipreps.org references them at:

   - `https://github.com/nipreps/fmriprep_stats/releases/latest/download/weekly.png`
   - `https://github.com/nipreps/fmriprep_stats/releases/latest/download/versionstream.png`

   These URLs are permanent 302 redirects to the latest release's blob, so the website renders the freshest plot every Monday without any rebuild.

2. **Repo keepalive** — the 60-day auto-disable on scheduled workflows is what caused the 2026-03-28..2026-04-12 daily-fetch gap when the repo went quiet. The new job touches `.github/last_weekly_run.txt` and pushes a heartbeat commit on every weekly run. As long as the schedule fires, the clock keeps resetting; the workflow self-perpetuates.

## What changes

A single new `publish-release` job in `update-plots.yml`, parallel to `publish-plots` (Dropbox), `needs: build-plots`. Six steps:

- Checkout (full token, needed for the push).
- Download the `weekly-plots` artifact produced by `build-plots`.
- Copy the date-prefixed PNGs to stable names (`weekly.png`, `versionstream.png`) and export `DATE`/`TAG`/`ISO_WEEK` to `$GITHUB_ENV`.
- Heartbeat commit: write `.github/last_weekly_run.txt`, commit + push if changed.
- `gh release create` (or `gh release upload --clobber` on same-day reruns).
- Prune `weekly-*` releases beyond `RETENTION=26` (~6 months) with `--cleanup-tag`.

Permissions are scoped: `contents: write` only on this new job. The existing `build-plots` and `publish-plots` jobs are untouched.

## Risk / caveat

- **Branch protection on `master`**: if any rule blocks `github-actions[bot]` from pushing, the heartbeat commit fails and the workflow exits non-zero (the release publication step won't run). If that turns out to be the case after merge, options are:
  - Allow the bot to bypass branch protection.
  - Push the heartbeat to `meta/heartbeat` instead of `master`.
  - Drop the heartbeat (release-tag creation alone *probably* counts as activity, but isn't documented to).

  I recommend trying `master` first and pivoting only if blocked.

## Test plan

- [ ] Merge this PR.
- [ ] `gh workflow run update-plots.yml -R nipreps/fmriprep_stats`.
- [ ] Confirm `publish-release` succeeds (build-plots and publish-plots are pre-existing).
- [ ] Verify `.github/last_weekly_run.txt` exists on `master` with today's UTC date.
- [ ] Verify the `weekly-YYYY-MM-DD` release exists with both PNGs attached.
- [ ] `curl -I https://github.com/nipreps/fmriprep_stats/releases/latest/download/weekly.png` returns 302 redirect to a valid blob.
- [ ] Re-dispatch on the same day; the existing release is updated (no duplicate, no error).
- [ ] After 27 weeks, oldest `weekly-*` release is pruned automatically.

## Out of scope (separate PRs)

- Updating nipreps.github.io to reference the new URLs.
- Bumping `actions/*@vN` to Node-24-compatible pins (audit item #4).
- Daily-fetch failure alerting (audit item #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)