### PR TITLE
ENH: bump GitHub Actions to Node-24 compatible pins

### DIFF
--- a/.github/workflows/export-daily-parquet.yml
+++ b/.github/workflows/export-daily-parquet.yml
@@ -82,7 +82,7 @@ jobs:
         run: ls -la "${PARQUET_OUTPUT_DIR}"
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: daily-parquet-export
           path: ${{ env.PARQUET_OUTPUT_DIR }}

--- a/.github/workflows/export-daily-parquet.yml
+++ b/.github/workflows/export-daily-parquet.yml
@@ -22,10 +22,10 @@ jobs:
           - 27017:27017
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -82,7 +82,7 @@ jobs:
         run: ls -la "${PARQUET_OUTPUT_DIR}"
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: daily-parquet-export
           path: ${{ env.PARQUET_OUTPUT_DIR }}

--- a/.github/workflows/sentry-fetch-daily.yml
+++ b/.github/workflows/sentry-fetch-daily.yml
@@ -17,10 +17,10 @@ jobs:
       DROPBOX_UPLOAD_RETRY_DELAY: ${{ vars.DROPBOX_UPLOAD_RETRY_DELAY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -44,7 +44,7 @@ jobs:
           done
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fmriprep-stats-${{ github.run_id }}
           path: "output/*.parquet"

--- a/.github/workflows/sentry-fetch-daily.yml
+++ b/.github/workflows/sentry-fetch-daily.yml
@@ -44,7 +44,7 @@ jobs:
           done
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: fmriprep-stats-${{ github.run_id }}
           path: "output/*.parquet"

--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -10,10 +10,10 @@ jobs:
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -31,7 +31,7 @@ jobs:
             --store parquet
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fmriprep-stats-parquet
           path: "*.parquet"

--- a/.github/workflows/sentry-fetch-pr.yml
+++ b/.github/workflows/sentry-fetch-pr.yml
@@ -31,7 +31,7 @@ jobs:
             --store parquet
 
       - name: Upload parquet artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: fmriprep-stats-parquet
           path: "*.parquet"

--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -13,10 +13,10 @@ jobs:
       PLOTS_DIR: /tmp/plots
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -24,7 +24,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Cache parquet downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-parquet
         with:
           path: ${{ env.PARQUET_DIR }}
@@ -76,7 +76,7 @@ jobs:
 
       # Keep parquet artifacts for ~5 weeks to match weekly cadence without ballooning storage.
       - name: Upload parquet artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: parquet-cache
           path: ${{ env.PARQUET_DIR }}
@@ -90,7 +90,7 @@ jobs:
             -o "${PLOTS_DIR}"
 
       - name: Upload plots artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}
@@ -103,10 +103,10 @@ jobs:
       PLOTS_DIR: /tmp/plots
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download plots artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}
@@ -137,13 +137,13 @@ jobs:
       RETENTION: 26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download plots artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}

--- a/.github/workflows/update-plots.yml
+++ b/.github/workflows/update-plots.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Keep parquet artifacts for ~5 weeks to match weekly cadence without ballooning storage.
       - name: Upload parquet artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: parquet-cache
           path: ${{ env.PARQUET_DIR }}
@@ -90,7 +90,7 @@ jobs:
             -o "${PLOTS_DIR}"
 
       - name: Upload plots artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download plots artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}
@@ -143,7 +143,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download plots artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: weekly-plots
           path: ${{ env.PLOTS_DIR }}


### PR DESCRIPTION
## Summary

Bumps every `actions/*` pin in `.github/workflows/` to the **first release of each that runs on Node 24 by default**:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | [v5 release notes](https://github.com/actions/checkout/releases/tag/v5.0.0) |
| `actions/setup-python` | `@v5` | `@v6` | [v6 release notes](https://github.com/actions/setup-python/releases/tag/v6.0.0) |
| `actions/cache` | `@v4` | `@v5` | [v5 release notes](https://github.com/actions/cache/releases/tag/v5.0.0) |
| `actions/upload-artifact` | `@v4` | `@v6` | [v5 was preliminary](https://github.com/actions/upload-artifact/releases/tag/v5.0.0), [v6 defaults to Node 24](https://github.com/actions/upload-artifact/releases/tag/v6.0.0) |
| `actions/download-artifact` | `@v4` | `@v7` | [v5 = path fix](https://github.com/actions/download-artifact/releases/tag/v5.0.0), [v6 = preliminary](https://github.com/actions/download-artifact/releases/tag/v6.0.0), [v7 defaults to Node 24](https://github.com/actions/download-artifact/releases/tag/v7.0.0) |

## Why

GitHub announced ([blog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)):

- **2026-06-02** — JS actions on Node 20 are auto-forced to Node 24 (with a warning).
- **2026-09-16** — Node 20 removed from runners; pre-Node-24 actions stop working.

Every recent run already shows the deprecation banner:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4. […]

## Why these specific pins (not the latest of each)

For each action, picked the **first major release whose `runs.using` is `node24` by default**, not the latest available. Subtlety: for `upload-artifact` and `download-artifact`, the major immediately above v4 (`v5`) had only "preliminary Node 24 support" but still defaulted to Node 20 — Codex caught this in review.

- `upload-artifact@v6.0.0`: "v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24."
- `download-artifact@v7.0.0`: "v6 had preliminary support for Node 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24."

The latest majors (`upload-artifact@v7`, `download-artifact@v8`) carry additional changes that don't affect us, but bumping further is unnecessary and a slightly larger blast radius. The `name` + `path` API surface we use is stable across v5..v8.

## Scope

- 4 workflow files touched: `sentry-fetch-daily.yml`, `sentry-fetch-pr.yml`, `update-plots.yml`, `export-daily-parquet.yml`.
- 18 pin-line updates total across two commits.
- No logic changes.

## Test plan

- [x] `python -c "import yaml; ..."` parses all four files.
- [ ] After merge, the next scheduled run of `sentry-fetch-daily.yml` (≈23:59 UTC) and `update-plots.yml` (Mon 22:00 UTC) succeed without the Node 20 deprecation banner.
- [ ] If anything regresses, revert is single-command (`git revert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)