### PR TITLE
ENH: pin requirements.txt to current versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,19 @@
-pymongo
-pandas
-pyarrow
-numpy
-packaging
-matplotlib
-scipy
-seaborn
-notebook
-nbconvert
-requests
-click
-tqdm
+# Pinned dependencies for the fmriprep_stats CLI and helper scripts.
+#
+# Refresh deliberately: when bumping a pin, run the full local plot pipeline
+# against the GHA parquet cache and confirm both `update-plots.yml` jobs
+# still pass before merging.
+
+pymongo==4.16.0
+pandas==3.0.0
+pyarrow==23.0.0
+numpy==2.4.1
+packaging==26.0
+matplotlib==3.10.8
+scipy==1.17.0
+seaborn==0.13.2
+notebook==7.5.3
+nbconvert==7.16.6
+requests==2.32.5
+click==8.3.1
+tqdm==4.67.1


### PR DESCRIPTION
## Summary

Replaces the 13 unpinned package names in `requirements.txt` with `==` pins matching the maintainer's local `fmriprep-stats` micromamba env (Python 3.11 — same as CI).

## Why

`update-plots.yml` runs every Monday at 22:00 UTC. With unpinned deps, any pandas / numpy / pyarrow / matplotlib release between Mondays would land in the next run unannounced — a silent, intermittent failure mode that's painful to bisect after the fact. The recent calendar-aware viz fix and the synthetic-gap test both passed against the pinned set, so this is a safe baseline to lock in.

## Pin choice

```
pymongo==4.16.0
pandas==3.0.0
pyarrow==23.0.0
numpy==2.4.1
packaging==26.0
matplotlib==3.10.8
scipy==1.17.0
seaborn==0.13.2
notebook==7.5.3
nbconvert==7.16.6
requests==2.32.5
click==8.3.1
tqdm==4.67.1
```

Direct deps only — no separate transitive lock. Pip resolves the ~100 transitive packages on each run; that's the normal trade-off (lower maintenance vs strict reproducibility). Comment at the top of the file flags that bumps are deliberate.

## Verification

```
$ pip install --dry-run --ignore-installed -r requirements.txt
# resolves to 110 packages on Python 3.11, no conflicts
```

## Test plan

- [x] `pip install --dry-run --ignore-installed` succeeds on Python 3.11.
- [ ] After merge, the next scheduled `sentry-fetch-daily.yml` run installs cleanly on a fresh GHA runner.
- [ ] The Monday `update-plots.yml` run then renders identical plots (post-#49 fix this should be byte-stable absent any data change).
- [ ] If pip resolution fails on the CI runner, revert is one command (`git revert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)