### PR TITLE
FIX: retry Dropbox transfers with backoff and degrade on rate limits

### DIFF
--- a/scripts/dropbox_parquet_sync.py
+++ b/scripts/dropbox_parquet_sync.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """Sync parquet files from Dropbox using refresh-token auth."""
+
 from __future__ import annotations
 
 import argparse
 import json
 import logging
+import os
+import time
 from pathlib import Path
 from typing import Iterable
 
@@ -12,9 +15,113 @@ import requests
 
 LOG = logging.getLogger("dropbox_parquet_sync")
 
+# Statuses worth retrying: Dropbox 429 (rate limit / traffic cap) and transient
+# 5xx from the edge. 4xx (e.g. 404 path/not_found, 401 auth) are permanent.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+# Never sleep longer than this between attempts, regardless of Retry-After.
+MAX_BACKOFF_SECONDS = 60.0
 
-def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
-    response = requests.post(
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _request_with_retry(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    max_attempts: int,
+    base_delay: float,
+    **kwargs,
+) -> requests.Response:
+    """Issue a request, retrying transient failures with exponential backoff.
+
+    Retries on HTTP 429/5xx and on connection/timeout errors. On 429 the
+    server's ``Retry-After`` header is honored when present; otherwise the wait
+    is ``base_delay * 2 ** (attempt - 1)``, capped at ``MAX_BACKOFF_SECONDS``.
+    Returns the final :class:`requests.Response` (which may still be non-OK if
+    retries were exhausted); re-raises the network error only when every attempt
+    failed to get a response at all.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = session.request(method, url, **kwargs)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as exc:
+            if attempt >= max_attempts:
+                raise
+            wait = min(base_delay * 2 ** (attempt - 1), MAX_BACKOFF_SECONDS)
+            LOG.warning(
+                "%s %s failed (%s); retry %d/%d in %.1fs",
+                method,
+                url,
+                exc.__class__.__name__,
+                attempt,
+                max_attempts,
+                wait,
+            )
+            time.sleep(wait)
+            continue
+
+        if response.status_code in RETRYABLE_STATUS and attempt < max_attempts:
+            wait = _retry_wait(response, base_delay, attempt)
+            LOG.warning(
+                "%s %s -> %d; retry %d/%d in %.1fs",
+                method,
+                url,
+                response.status_code,
+                attempt,
+                max_attempts,
+                wait,
+            )
+            time.sleep(wait + 0.1)
+            continue
+
+        return response
+
+
+def _retry_wait(response: requests.Response, base_delay: float, attempt: int) -> float:
+    """Backoff seconds for a retryable response, honoring Retry-After on 429."""
+    retry_after = response.headers.get("Retry-After")
+    if retry_after is not None:
+        try:
+            return min(float(retry_after), MAX_BACKOFF_SECONDS)
+        except ValueError:
+            pass
+    return min(base_delay * 2 ** (attempt - 1), MAX_BACKOFF_SECONDS)
+
+
+def get_access_token(
+    session: requests.Session,
+    app_key: str,
+    app_secret: str,
+    refresh_token: str,
+    *,
+    max_attempts: int,
+    base_delay: float,
+) -> str:
+    response = _request_with_retry(
+        session,
+        "POST",
         "https://api.dropboxapi.com/oauth2/token",
         data={
             "grant_type": "refresh_token",
@@ -23,13 +130,22 @@ def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
             "client_secret": app_secret,
         },
         timeout=30,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
     )
     response.raise_for_status()
     payload = response.json()
     return payload["access_token"]
 
 
-def list_folder_entries(access_token: str, path: str) -> Iterable[dict]:
+def list_folder_entries(
+    session: requests.Session,
+    access_token: str,
+    path: str,
+    *,
+    max_attempts: int,
+    base_delay: float,
+) -> Iterable[dict]:
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
@@ -39,7 +155,16 @@ def list_folder_entries(access_token: str, path: str) -> Iterable[dict]:
     url = "https://api.dropboxapi.com/2/files/list_folder"
 
     while True:
-        response = requests.post(url, headers=headers, json=payload, timeout=30)
+        response = _request_with_retry(
+            session,
+            "POST",
+            url,
+            headers=headers,
+            json=payload,
+            timeout=30,
+            max_attempts=max_attempts,
+            base_delay=base_delay,
+        )
         response.raise_for_status()
         data = response.json()
         entries.extend(data.get("entries", []))
@@ -52,19 +177,32 @@ def list_folder_entries(access_token: str, path: str) -> Iterable[dict]:
     return entries
 
 
-def download_file(access_token: str, dropbox_path: str, destination: Path) -> None:
+def download_file(
+    session: requests.Session,
+    access_token: str,
+    dropbox_path: str,
+    destination: Path,
+    *,
+    max_attempts: int,
+    base_delay: float,
+) -> None:
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Dropbox-API-Arg": json.dumps({"path": dropbox_path}),
     }
-    response = requests.post(
+    response = _request_with_retry(
+        session,
+        "POST",
         "https://content.dropboxapi.com/2/files/download",
         headers=headers,
         timeout=300,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
     )
     if not response.ok:
         # Surface Dropbox's specific error tag (e.g. path/not_found) which lives
-        # in the JSON body — raise_for_status() alone hides it.
+        # in the JSON body — raise_for_status() alone hides it. The response is
+        # attached so callers can classify transient (429/5xx) vs permanent.
         raise requests.exceptions.HTTPError(
             f"{response.status_code} for {dropbox_path}: {response.text or '<empty>'}",
             response=response,
@@ -79,6 +217,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--app-key", required=True, help="Dropbox app key")
     parser.add_argument("--app-secret", required=True, help="Dropbox app secret")
     parser.add_argument("--refresh-token", required=True, help="Dropbox refresh token")
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=_env_int("DROPBOX_SYNC_RETRIES", 5),
+        help="Max attempts per request (env: DROPBOX_SYNC_RETRIES)",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=_env_float("DROPBOX_SYNC_RETRY_DELAY", 2.0),
+        help="Base backoff seconds (env: DROPBOX_SYNC_RETRY_DELAY)",
+    )
+    parser.add_argument(
+        "--request-pacing",
+        type=float,
+        default=_env_float("DROPBOX_SYNC_REQUEST_PACING", 0.1),
+        help="Seconds to sleep between downloads (env: DROPBOX_SYNC_REQUEST_PACING)",
+    )
     return parser.parse_args()
 
 
@@ -91,8 +247,22 @@ def load_metadata(metadata_path: Path) -> dict[str, dict[str, str | int]]:
         return {}
 
 
-def write_metadata(metadata_path: Path, metadata: dict[str, dict[str, str | int]]) -> None:
-    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+def write_metadata(
+    metadata_path: Path, metadata: dict[str, dict[str, str | int]]
+) -> None:
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
+def _is_transient(exc: Exception) -> bool:
+    """A download error is transient if it's a network blip or a 429/5xx."""
+    if isinstance(
+        exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+    ):
+        return True
+    response = getattr(exc, "response", None)
+    return response is not None and response.status_code in RETRYABLE_STATUS
 
 
 def main() -> int:
@@ -106,14 +276,25 @@ def main() -> int:
     metadata_path = parquet_dir / ".dropbox_metadata.json"
     cached_metadata = load_metadata(metadata_path)
 
-    access_token = get_access_token(args.app_key, args.app_secret, args.refresh_token)
-    entries = list(list_folder_entries(access_token, dropbox_path))
-    LOG.info(
-        "Listed %d entries at Dropbox path %r", len(entries), dropbox_path or "/"
+    session = requests.Session()
+    retry_kwargs = {
+        "max_attempts": max(1, args.retries),
+        "base_delay": args.retry_delay,
+    }
+
+    # Auth and listing failures are catastrophic — after exhausting retries the
+    # raised exception propagates and the job exits non-zero.
+    access_token = get_access_token(
+        session, args.app_key, args.app_secret, args.refresh_token, **retry_kwargs
     )
+    entries = list(
+        list_folder_entries(session, access_token, dropbox_path, **retry_kwargs)
+    )
+    LOG.info("Listed %d entries at Dropbox path %r", len(entries), dropbox_path or "/")
 
     fetched = skipped = failed = 0
-    failures: list[tuple[str, str]] = []
+    transient_failures: list[tuple[str, str]] = []
+    permanent_failures: list[tuple[str, str]] = []
 
     for entry in entries:
         if entry.get(".tag") != "file":
@@ -125,14 +306,25 @@ def main() -> int:
         expected_rev = entry.get("rev")
         expected_size = entry.get("size")
         cached_entry = cached_metadata.get(dropbox_file, {})
-        if local_path.exists() and expected_rev and cached_entry.get("rev") == expected_rev:
+        if (
+            local_path.exists()
+            and expected_rev
+            and cached_entry.get("rev") == expected_rev
+        ):
             skipped += 1
             continue
         try:
-            download_file(access_token, dropbox_file, local_path)
-        except requests.exceptions.HTTPError as exc:
+            download_file(
+                session, access_token, dropbox_file, local_path, **retry_kwargs
+            )
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as exc:
             failed += 1
-            failures.append((dropbox_file, str(exc)))
+            bucket = transient_failures if _is_transient(exc) else permanent_failures
+            bucket.append((dropbox_file, str(exc)))
             LOG.error("download FAILED for %s: %s", dropbox_file, exc)
             continue
         cached_metadata[dropbox_file] = {
@@ -147,22 +339,40 @@ def main() -> int:
                 skipped,
                 failed,
             )
+        if args.request_pacing > 0:
+            time.sleep(args.request_pacing)
 
+    # Persist whatever we did fetch so a partial pull converges on the next run.
     write_metadata(metadata_path, cached_metadata)
 
     LOG.info(
-        "summary: fetched=%d skipped(cached)=%d failed=%d",
-        fetched,
-        skipped,
-        failed,
+        "summary: fetched=%d skipped(cached)=%d failed=%d", fetched, skipped, failed
     )
-    if failures:
-        LOG.error("download failures (%d):", len(failures))
-        for path, msg in failures[:25]:
+
+    for label, bucket in (
+        ("transient", transient_failures),
+        ("permanent", permanent_failures),
+    ):
+        if not bucket:
+            continue
+        LOG.error("%s download failures (%d):", label, len(bucket))
+        for path, msg in bucket[:25]:
             LOG.error("  %s -> %s", path, msg)
-        if len(failures) > 25:
-            LOG.error("  ... and %d more", len(failures) - 25)
+        if len(bucket) > 25:
+            LOG.error("  ... and %d more", len(bucket) - 25)
+
+    # Catastrophic only when nothing at all came through despite attempts — that
+    # signals broken auth/config, not a rate-limit hiccup. A partial pull is fine:
+    # plots render from cache + whatever was fetched, and leftover files retry next run.
+    if failed and fetched == 0:
+        LOG.error("no files could be downloaded; failing job")
         return 1
+    if failed:
+        LOG.warning(
+            "%d file(s) could not be downloaded this run; continuing with a "
+            "partial snapshot (will retry on the next run)",
+            failed,
+        )
     return 0
 
 

--- a/scripts/dropbox_upload_plots.py
+++ b/scripts/dropbox_upload_plots.py
@@ -1,16 +1,118 @@
 #!/usr/bin/env python3
 """Upload plot artifacts to Dropbox using refresh-token auth."""
+
 from __future__ import annotations
 
 import argparse
 import json
+import logging
+import os
+import time
 from pathlib import Path
 
 import requests
 
+LOG = logging.getLogger("dropbox_upload_plots")
 
-def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
-    response = requests.post(
+# Dropbox 429 (rate limit) and transient edge 5xx are worth retrying; 4xx are not.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+MAX_BACKOFF_SECONDS = 60.0
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _request_with_retry(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    max_attempts: int,
+    base_delay: float,
+    **kwargs,
+) -> requests.Response:
+    """Issue a request, retrying transient failures with exponential backoff.
+
+    Retries on HTTP 429/5xx and on connection/timeout errors. On 429 the
+    server's ``Retry-After`` header is honored when present; otherwise the wait
+    is ``base_delay * 2 ** (attempt - 1)``, capped at ``MAX_BACKOFF_SECONDS``.
+    Returns the final response (possibly non-OK if retries were exhausted).
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = session.request(method, url, **kwargs)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as exc:
+            if attempt >= max_attempts:
+                raise
+            wait = min(base_delay * 2 ** (attempt - 1), MAX_BACKOFF_SECONDS)
+            LOG.warning(
+                "%s %s failed (%s); retry %d/%d in %.1fs",
+                method,
+                url,
+                exc.__class__.__name__,
+                attempt,
+                max_attempts,
+                wait,
+            )
+            time.sleep(wait)
+            continue
+
+        if response.status_code in RETRYABLE_STATUS and attempt < max_attempts:
+            retry_after = response.headers.get("Retry-After")
+            wait = base_delay * 2 ** (attempt - 1)
+            if retry_after is not None:
+                try:
+                    wait = float(retry_after)
+                except ValueError:
+                    pass
+            wait = min(wait, MAX_BACKOFF_SECONDS)
+            LOG.warning(
+                "%s %s -> %d; retry %d/%d in %.1fs",
+                method,
+                url,
+                response.status_code,
+                attempt,
+                max_attempts,
+                wait,
+            )
+            time.sleep(wait + 0.1)
+            continue
+
+        return response
+
+
+def get_access_token(
+    session: requests.Session,
+    app_key: str,
+    app_secret: str,
+    refresh_token: str,
+    *,
+    max_attempts: int,
+    base_delay: float,
+) -> str:
+    response = _request_with_retry(
+        session,
+        "POST",
         "https://api.dropboxapi.com/oauth2/token",
         data={
             "grant_type": "refresh_token",
@@ -19,51 +121,116 @@ def get_access_token(app_key: str, app_secret: str, refresh_token: str) -> str:
             "client_secret": app_secret,
         },
         timeout=30,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
     )
     response.raise_for_status()
     payload = response.json()
     return payload["access_token"]
 
 
-def upload_file(access_token: str, dropbox_path: str, file_path: Path) -> None:
+def upload_file(
+    session: requests.Session,
+    access_token: str,
+    dropbox_path: str,
+    file_path: Path,
+    *,
+    max_attempts: int,
+    base_delay: float,
+) -> None:
     headers = {
         "Authorization": f"Bearer {access_token}",
-        "Dropbox-API-Arg": json.dumps({"path": dropbox_path, "mode": "overwrite", "mute": True}),
+        "Dropbox-API-Arg": json.dumps(
+            {"path": dropbox_path, "mode": "overwrite", "mute": True}
+        ),
         "Content-Type": "application/octet-stream",
     }
-    response = requests.post(
+    response = _request_with_retry(
+        session,
+        "POST",
         "https://content.dropboxapi.com/2/files/upload",
         headers=headers,
         data=file_path.read_bytes(),
         timeout=300,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
     )
-    response.raise_for_status()
+    if not response.ok:
+        raise requests.exceptions.HTTPError(
+            f"{response.status_code} for {dropbox_path}: {response.text or '<empty>'}",
+            response=response,
+        )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Upload plots to Dropbox")
     parser.add_argument("--plots-dir", required=True, help="Local plots directory")
-    parser.add_argument("--dropbox-path", required=True, help="Dropbox destination path")
+    parser.add_argument(
+        "--dropbox-path", required=True, help="Dropbox destination path"
+    )
     parser.add_argument("--app-key", required=True, help="Dropbox app key")
     parser.add_argument("--app-secret", required=True, help="Dropbox app secret")
     parser.add_argument("--refresh-token", required=True, help="Dropbox refresh token")
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=_env_int("DROPBOX_UPLOAD_RETRIES", 5),
+        help="Max attempts per request (env: DROPBOX_UPLOAD_RETRIES)",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=_env_float("DROPBOX_UPLOAD_RETRY_DELAY", 2.0),
+        help="Base backoff seconds (env: DROPBOX_UPLOAD_RETRY_DELAY)",
+    )
     return parser.parse_args()
 
 
-def main() -> None:
+def main() -> int:
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(message)s", level=logging.INFO
+    )
     args = parse_args()
     plots_dir = Path(args.plots_dir)
     dropbox_base = args.dropbox_path.rstrip("/")
 
-    access_token = get_access_token(args.app_key, args.app_secret, args.refresh_token)
+    session = requests.Session()
+    retry_kwargs = {
+        "max_attempts": max(1, args.retries),
+        "base_delay": args.retry_delay,
+    }
 
+    access_token = get_access_token(
+        session, args.app_key, args.app_secret, args.refresh_token, **retry_kwargs
+    )
+
+    failures: list[tuple[str, str]] = []
     for file_path in plots_dir.rglob("*"):
         if file_path.is_dir():
             continue
         rel_path = file_path.relative_to(plots_dir).as_posix()
         dropbox_path = f"{dropbox_base}/{rel_path}"
-        upload_file(access_token, dropbox_path, file_path)
+        try:
+            upload_file(session, access_token, dropbox_path, file_path, **retry_kwargs)
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ) as exc:
+            failures.append((dropbox_path, str(exc)))
+            LOG.error("upload FAILED for %s: %s", dropbox_path, exc)
+            continue
+        LOG.info("uploaded %s -> %s", file_path, dropbox_path)
+
+    # Plots are the product of the run — if any could not be uploaded after
+    # retries, fail so the failure is visible rather than silently dropped.
+    if failures:
+        LOG.error("upload failures (%d):", len(failures))
+        for path, msg in failures:
+            LOG.error("  %s -> %s", path, msg)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

The weekly **Update plots** workflow [failed](https://github.com/nipreps/fmriprep_stats/actions/runs/29291428907/job/86955657559): the `Download parquet from Dropbox` step hit a Dropbox `429 Too many requests` ("traffic limits") on a single file (`/2026-04-12-started.parquet`).

`scripts/dropbox_parquet_sync.py` downloaded each file with one raw POST in a serial loop with **no retry and no 429 handling**, and `main()` returned non-zero if *any* file failed — so a single transient throttle killed the whole `build-plots` job, even though the `actions/cache` + prior-artifact fallback already held nearly all the data. The flat Dropbox folder (now 4256 entries, growing ~3 files/day) and the un-paced back-to-back requests are what trip the limit in the first place.

## Changes

- **`_request_with_retry()`** — retries on `429`/`5xx` and connection/timeout errors with exponential backoff, **honoring `Retry-After`** on 429s (capped at 60s), over a shared `requests.Session`. Modeled on the existing Sentry backoff in `src/api.py`.
- **Request pacing** — a small configurable sleep between downloads so steady-state volume stays under the limit.
- **Graceful degradation** in `dropbox_parquet_sync.py` — failures are split into transient (429/5xx/network) vs permanent (404/auth). A partial pull logs a warning and **exits 0** (plots render from cache + fetched files; the rest are left un-persisted and retry next run). Exit `1` only when *nothing* downloaded despite trying — the signature of broken auth/config, not a hiccup.
- **`dropbox_upload_plots.py`** — same latent flaw, same retry treatment; kept strict (plots are the run's product, so it fails if any plot ultimately can't be uploaded).
- New knobs: `DROPBOX_SYNC_RETRIES` / `DROPBOX_SYNC_RETRY_DELAY` / `DROPBOX_SYNC_REQUEST_PACING`, `DROPBOX_UPLOAD_RETRIES` / `DROPBOX_UPLOAD_RETRY_DELAY`.

No `continue-on-error` was added to the workflow — the script's tolerant exit code is the right control point; a blanket `continue-on-error` would also swallow real breakage.

## Verification

Local test suites against a stub HTTP server (no Dropbox creds needed), all passing:
- **Retry helper**: 429→200 honors `Retry-After`; 5xx exponential backoff (2.1s, 4.1s); 404 not retried; exhausted 429 returns final response; `Retry-After` capped at 60s; transient/permanent classification.
- **`main()` degrade policy**: one transient 429 → exit 0 with the good files persisted and the failed one left to retry; all files 429 → exit 1; all success → exit 0; a permanent 404 among successes → exit 0.

`ruff check` and `ruff format --check` clean on both files.

Remaining end-to-end check: `gh workflow run update-plots.yml --ref fix/dropbox-sync-backoff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)